### PR TITLE
Add subsystem cl-quil/tools -- cl-quil language tools for developers

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -289,3 +289,28 @@
                (:file "suite")
                (:file "stabilizer-group-tests")
                (:file "cleve-gottesman-tests")))
+
+(asdf:defsystem #:cl-quil/tools
+  :description "Tools for cl-quil developers."
+  :license "Apache License 2.0 (See LICENSE.txt)"
+  :depends-on (#:cl-quil)
+  :in-order-to ((asdf:test-op (asdf:test-op #:cl-quil/tools-tests)))
+  :around-compile (lambda (compile)
+                    (let (#+sbcl (sb-ext:*derive-function-types* t))
+                      (funcall compile)))
+  :pathname "src/tools/"
+  :serial t
+  :components ((:file "package")))
+
+(asdf:defsystem #:cl-quil/tools-tests
+  :description "Regression tests for CL-Quil tools for developers."
+  :license "Apache License 2.0 (See LICENSE.txt)"
+  :depends-on (#:cl-quil-tests
+               #:cl-quil/tools)
+  :perform (asdf:test-op (o s)
+                         (uiop:symbol-call ':cl-quil.tools-tests
+                                           '#:run-tools-tests))
+  :pathname "tests/tools/"
+  :serial t
+  :components ((:file "package")
+               (:file "suite")))

--- a/src/tools/package.lisp
+++ b/src/tools/package.lisp
@@ -1,0 +1,19 @@
+;;;; src/tools/package.lisp
+;;;;
+;;;; Author: Mark David
+
+;;; Allegro (and other Lisps) don't support the non-standard "package
+;;; local nicknames".
+#-(or sbcl ecl ccl)
+(rename-package :alexandria :alexandria '(:a))
+
+(defpackage #:cl-quil.tools
+  (:nicknames #:tools)
+  (:use #:cl
+        #:cl-quil)
+  #+(or sbcl ecl ccl)
+  (:local-nicknames (:a :alexandria))
+
+  (:export
+   )
+  )

--- a/tests/tools/package.lisp
+++ b/tests/tools/package.lisp
@@ -1,0 +1,18 @@
+;;;; tests/quilt/package.lisp
+;;;;
+;;;; Author: Mark David
+
+;;; Allegro (and other Lisps) don't support the non-standard "package
+;;; local nicknames".
+#-(or sbcl ecl ccl)
+(rename-package :alexandria :alexandria '(:a))
+
+(fiasco:define-test-package #:cl-quil.tools-tests
+  #+(or sbcl ecl ccl)
+  (:local-nicknames (:a :alexandria))
+  (:use #:cl-quil #:cl-quil.quilt)
+
+  ;; suite.lisp
+  (:export
+   #:run-tools-tests)
+  (:shadowing-import-from #:cl-quil #:pi))

--- a/tests/tools/suite.lisp
+++ b/tests/tools/suite.lisp
@@ -1,0 +1,23 @@
+;;;; tests/tools/suite.lisp
+;;;;
+;;;; Author: Mark David
+
+(in-package #:cl-quil.tools-tests)
+
+(defun run-tools-tests (&key (verbose nil) (headless nil))
+  "Run all CL-QUIL/TOOLS tests. If VERBOSE is T, print out lots of test info. If HEADLESS is T, disable interactive debugging and quit on completion."
+  ;; Bug in Fiasco commit fe89c0e924c22c667cc11c6fc6e79419fc7c1a8b
+  (setf fiasco::*test-run-standard-output* (make-broadcast-stream
+                                            *standard-output*))
+  (cond
+    ((null headless)
+     (run-package-tests :package ':cl-quil.tools-tests
+                        :verbose verbose
+                        :describe-failures t
+                        :interactive t))
+    (t
+     (let ((successp (run-package-tests :package ':cl-quil.tools-tests
+                                        :verbose t
+                                        :describe-failures t
+                                        :interactive nil)))
+       (uiop:quit (if successp 0 1))))))


### PR DESCRIPTION
This is a stub for now, but we'll add to it later.

In anticipation of adding some dev-tools type modules, this introduces
a new subsystem cl-quil/tools that new modules can hang off of. For
now this is a stub, but later we may add, e.g., hasse-stuff (a little
utility for doing Hasse diagrams for logical schedulers) and circ-viz
(some tools for circuit visualization), maybe with different names.

The two anticipated new modules, and more to come later probably, are
not being added to cl-quil (core) system because they are
nice-to-haves but non-core. In addition, these two in particular have
weird dependencies like GraphViz and LaTeX, so cordoning them off
keeps the core a bit cleaner.

Issue "Print a logical-schedule as a Hasse diagram #712" relates
loosely to this in that Hasse stuff is planned to be added to this
stub system, so it was a motivater for this general approach.