### PR TITLE
Load foreign libraries at run time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
 
       - name: Run a multi-line script
         run: |
-          docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
-          docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-cl-quil
-          docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
+          docker build -t rigetti/quilc:${GITHUB_SHA} .
+          docker run --rm --entrypoint=make rigetti/quilc:${GITHUB_SHA} test-cl-quil
+          docker rmi rigetti/quilc:${GITHUB_SHA}
 
   test-quilc:
     name: Test quilc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,9 @@ jobs:
 
       - name: Run a multi-line script
         run: |
-          sudo apt install sbcl
-          make quicklisp
-          sudo make install-test-deps
-          make test-cl-quil
+          docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
+          docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-cl-quil
+          docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
 
   test-quilc:
     name: Test quilc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,9 +15,9 @@ test-cl-quil:
     - branches
   image: docker:stable
   script:
-    - docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
+    - docker build -t rigetti/quilc:${GITHUB_SHA} .
     - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-cl-quil
-    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
+    - docker rmi rigetti/quilc:${GITHUB_SHA}
 
 test-quilt:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,9 +15,9 @@ test-cl-quil:
     - branches
   image: docker:stable
   script:
-    - docker build -t rigetti/quilc:${GITHUB_SHA} .
-    - docker run --rm --entrypoint=make rigetti/quilc:${GITHUB_SHA} test-cl-quil
-    - docker rmi rigetti/quilc:${GITHUB_SHA}
+    - docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
+    - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-cl-quil
+    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
 
 test-quilt:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ test-cl-quil:
   image: docker:stable
   script:
     - docker build -t rigetti/quilc:${GITHUB_SHA} .
-    - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-cl-quil
+    - docker run --rm --entrypoint=make rigetti/quilc:${GITHUB_SHA} test-cl-quil
     - docker rmi rigetti/quilc:${GITHUB_SHA}
 
 test-quilt:

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -10,34 +10,57 @@
 
 (require 'asdf)
 
+(defun unload-libraries ()
+  "Unloads foreign libraries using CFFI and returns a list of the closed libraries"
+  ;; A dumped lisp image will use the *exact* foreign library name
+  ;; that was provided at the time the image was dumped. If the
+  ;; library is moved/renamed, CFFI will not try to load an
+  ;; alternative, thus we unload all foreign libraries and tell CFFI
+  ;; to load them at run-time allowing it to pick up alternatives.
+  ;;
+  ;; For a concrete example: when we build the SDK packages for
+  ;; debian, the FFI library available is typically libffi.so.6. On
+  ;; newer versions of debian the library is named libffi.so.7, so
+  ;; when we try to load the lisp image on a newer debian version, it
+  ;; fails with an error about not finding libffi.so.6.
+  (let ((foreign-libraries
+          (mapcar (lambda (library) (funcall (find-symbol "FOREIGN-LIBRARY-NAME" :cffi) library))
+                  (funcall (find-symbol "LIST-FOREIGN-LIBRARIES" :cffi) :loaded-only t))))
+    (map nil (find-symbol "CLOSE-FOREIGN-LIBRARY" :cffi) foreign-libraries)
+    (reverse foreign-libraries)))
+
+(defun load-libraries (libraries)
+  "Loads all foreign libraries in LIBRARIES"
+  (pushnew #P"/usr/local/lib/rigetti/" (symbol-value (find-symbol "*FOREIGN-LIBRARY-DIRECTORIES*" :cffi))
+           :test #'equal)
+  (map nil (find-symbol "LOAD-FOREIGN-LIBRARY" :cffi) libraries)
+  nil)
+
+(defun option-present-p (name)
+  (find name sb-ext:*posix-argv* :test 'string=))
+
 (let ((*default-pathname-defaults* (make-pathname :type nil
                                                   :name nil
                                                   :defaults *load-truename*))
       (output-file (make-pathname :name "quilc"
                                   :type #+win32 "exe" #-win32 nil))
       (system-table (make-hash-table :test 'equal))
-      (entry-point "quilc::entry-point"))
-  (flet ((option-present-p (name)
-           (find name sb-ext:*posix-argv* :test 'string=))
-         (make-toplevel-function (entry)
-           (lambda ()
-             (with-simple-restart (abort "Abort")
-               (funcall (read-from-string entry)
-                        sb-ext:*posix-argv*))))
-         (load-systems-table ()
-           (unless (probe-file "system-index.txt")
-             (error "Generate system-index.txt with 'make system-index.txt' first."))
-           (setf (gethash "quilc" system-table) (merge-pathnames "quilc.asd"))
-           (with-open-file (stream "system-index.txt")
-             (loop
-               :for system-file := (read-line stream nil)
-               :while system-file
-               :do (setf (gethash (pathname-name system-file) system-table)
-                         (merge-pathnames system-file)))))
-         (local-system-search (name)
-           (values (gethash name system-table)))
-         (strip-version-githash (version)
-           (subseq version 0 (position #\- version :test #'eql))))
+      (entry-point "ENTRY-POINT")
+      (libraries nil))
+  (labels ((load-systems-table ()
+             (unless (probe-file "system-index.txt")
+               (error "Generate system-index.txt with 'make system-index.txt' first."))
+             (setf (gethash "quilc" system-table) (merge-pathnames "quilc.asd"))
+             (with-open-file (stream "system-index.txt")
+               (loop
+                 :for system-file := (read-line stream nil)
+                 :while system-file
+                 :do (setf (gethash (pathname-name system-file) system-table)
+                           (merge-pathnames system-file)))))
+           (local-system-search (name)
+             (values (gethash name system-table)))
+           (strip-version-githash (version)
+             (subseq version 0 (position #\- version :test #'eql))))
     (load-systems-table)
     (push #'local-system-search asdf:*system-definition-search-functions*)
 
@@ -50,16 +73,23 @@
     ;; TODO Fix tweedledum
     ;; #-win32
     ;; (asdf:load-system "cl-quil/tweedledum")
-    (funcall (read-from-string "quilc::setup-debugger"))
+    (funcall (find-symbol "SETUP-DEBUGGER" :quilc))
     (when (option-present-p "--quilc-sdk")
       (load "app/src/mangle-shared-objects.lisp"))
     (when (option-present-p "--unsafe")
       (format t "~&Using unsafe entry point~%")
-      (setf entry-point "quilc::%entry-point"))
+      (setf entry-point "%ENTRY-POINT"))
     (force-output)
+    (setf libraries (unload-libraries))
     (sb-ext:save-lisp-and-die output-file
                               :compression #+sb-core-compression t
-                                           #-sb-core-compression nil
+                              #-sb-core-compression nil
                               :save-runtime-options t
                               :executable t
-                              :toplevel (make-toplevel-function entry-point))))
+                              :toplevel
+                              (let ((entry-sym (find-symbol entry-point :quilc)))
+                                (lambda ()
+                                  (load-libraries libraries)
+                                  (with-simple-restart (abort "Abort")
+                                    (funcall entry-sym
+                                             sb-ext:*posix-argv*)))))))


### PR DESCRIPTION
1. Back in #702 I tried to get foreign libraries to load at run time vs. hard-coding library paths in the compiled executable. It was broken, however, so I reverted it a while back. Today I figured out how it was broken: when the libraries are "unloaded" and saved into a list, they're saved in reverse order. So when quilc is compiled the last library it links to is expokit because it depends on lapack which is loaded earlier. When I was loading from that list at run time I would end up trying to load expokit _before_ lapack, and CFFI would fail with an unhelpful error: instead of saying _why_ a library couldn't be loaded, it would just say that it couldn't be loaded. Anyhow, reversing the list fixes the problem. Have a good weekend.

2. I've changed the tests here to use a specific version of QVM. This fixes a compatibility issue (see #723).