### PR TITLE
[#723] fix error in test-measure-semantics due to change in qvm

### DIFF
--- a/tests/misc-tests.lisp
+++ b/tests/misc-tests.lisp
@@ -297,11 +297,10 @@
   "Make a DENSITY-QVM that is initialized in the basis state described by BASIS-INDEX.
 
 To put the density matrix into the basis state, e.g., |01><11|, we would choose BASIS-INDEX = 7. In general, the basis state |a><b| is prepared by choosing BASIS-INDEX = (2^N * a + b)."
-  (let ((amps (make-array (expt 2 (* 2 num-qubits))
-                          :element-type 'qvm:cflonum
-                          :initial-element (qvm:cflonum 0))))
-    (setf (aref amps basis-index) (qvm:cflonum 1))
-    (qvm:make-density-qvm num-qubits :amplitudes amps)))
+  (let ((qvm (qvm:make-density-qvm num-qubits)))
+    (setf (aref (qvm::amplitudes qvm) 0) (qvm:cflonum 0)
+          (aref (qvm::amplitudes qvm) basis-index) (qvm:cflonum 1))
+    qvm))
 
 ;; Our test below is built on the following idea: rather than directly
 ;; calculating the entire superoperator encoding the pre- and post-compilation


### PR DESCRIPTION
This fixes issue 723 in quil (not qvm). A subfunction of test function
test-measure-semantics in quil (%make-density-qvm-initialized-in-basis
in tests/misc-tests.lisp) had been calling qvm system and qvm package
function make-density-qvm with :amplitudes keyword. It turns out that
this argument was being ignored. Its being ignored was apparently not
a problem for this test.  However, in a more recent version of QVM,
the keyword arg began being passed along to make-instance on
DENSITY-QVM, and this is not a supported init arg, so the test
produced an error message like the following:

  Invalid initialization argument:
    :AMPLITUDES
  in call for class #<STANDARD-CLASS QVM:DENSITY-QVM>.

The new code performs the desired functionality without the keyword
arg, and is actually simpler.

Resolves: #723

Note: this bug caused quilc CI failures due to the CI using qvm
version 1.17.2.  The CI was subsequently patched to use the older
version of qvm. This commit will work with both the old version
(v1.17.1) and the new (v1.17.2).

Note: the change in qvm that broke the quilc test was not caught by
the CI until now because quilc's CI used an older version of qvm
(qvm-v1.17.1) until just recently.  The version chosen by the CI is
determined by Quicklisp, which is loosely tied to version of QVM, but
my have a lag of weeks or longer.