### PR TITLE
add BLOCH gate & fix DEFGATE parsing bug

### DIFF
--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -316,15 +316,17 @@ The Pauli sum is recorded as a list of PAULI-TERM objects, stored in the TERMS s
 
 ;;; Load all of the standard gates from src/quil/stdgates.quil
 (global-vars:define-global-var **default-gate-definitions**
-    (let ((table (make-hash-table :test 'equal))
-          (gate-defs (remove-if-not (lambda (obj) (typep obj 'gate-definition))
-                      (parse-quil-into-raw-program
-                       (a:read-file-into-string
-                        (asdf:system-relative-pathname
-                         "cl-quil" "src/quil/stdgates.quil"))))))
-      (dolist (gate-def gate-defs table)
-        (setf (gethash (gate-definition-name gate-def) table)
-              gate-def)))
+    (let ((stdgates-file (asdf:system-relative-pathname
+                          "cl-quil" "src/quil/stdgates.quil")))
+      (format t "~&; loading standard gates from ~A~%" stdgates-file)
+      (let ((table (make-hash-table :test 'equal))
+            (gate-defs
+              (remove-if-not (lambda (obj) (typep obj 'gate-definition))
+                             (parse-quil-into-raw-program
+                              (a:read-file-into-string stdgates-file)))))
+        (dolist (gate-def gate-defs table)
+          (setf (gethash (gate-definition-name gate-def) table)
+                gate-def))))
   "A table of default gate definitions, mapping string name to a GATE-DEFINITION object.")
 
 (defun standard-gate-names ()

--- a/src/quil/stdgates.quil
+++ b/src/quil/stdgates.quil
@@ -157,3 +157,8 @@ DEFGATE CAN(%alpha, %beta, %gamma):
     0, (cis((%alpha+%beta+%gamma)/(-2))+cis((%beta+%gamma-%alpha)/2))/2, (cis((%alpha+%beta+%gamma)/(-2))-cis((%beta+%gamma-%alpha)/2))/2, 0
     0, (cis((%alpha+%beta+%gamma)/(-2))-cis((%beta+%gamma-%alpha)/2))/2, (cis((%alpha+%beta+%gamma)/(-2))+cis((%beta+%gamma-%alpha)/2))/2, 0
     (cis((%alpha-%beta+%gamma)/2)-cis((%alpha+%beta-%gamma)/2))/2, 0, 0, (cis((%alpha+%beta-%gamma)/2)+cis((%alpha-%beta+%gamma)/2))/2
+
+DEFGATE BLOCH(%alpha, %beta, %gamma) q AS PAULI-SUM:
+    X(%alpha) q
+    Y(%beta) q
+    Z(%gamma) q

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -140,6 +140,19 @@ ISWAP 5 2"))
          (2q-code (program-2q-instructions cp)))
     (is (every (link-nativep chip) 2q-code))))
 
+(deftest test-bloch-gate-compilation ()
+  (let* ((chip (quil::build-ibm-qx5))
+         (pp (parse-quil "
+BLOCH(0,0,0) 0
+BLOCH(0.1, 0.2, 0.3) 1
+CONTROLLED BLOCH(-pi, pi/2, 0.1) 2 3
+DAGGER BLOCH(-0.1, -0.2, -0.3) 4
+"))
+         (cp (let ((quil::*compress-carefully* nil))
+               (compiler-hook pp chip)))
+         (2q-code (program-2q-instructions cp)))
+    (is (every (link-nativep chip) 2q-code))))
+
 (deftest test-cnot-triangle ()
   (let* ((chip (quil::build-nq-linear-chip 3 :architecture ':cnot))
          (orig-prog (quil::parse-quil "

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -247,6 +247,15 @@ DEFCIRCUIT FOO(%a) q:
       (signals quil-parse-error
         (parse-quil (read-quil-file path1))))))
 
+(deftest test-pauli-sum-parsing ()
+  (let ((p (parse-quil-into-raw-program "
+DEFGATE FOO(%a) q AS PAULI-SUM:
+    X(%a) q
+
+")))
+    (is (listp p))
+    (is (= 1 (length p)))
+    (is (typep (first p) 'cl-quil::exp-pauli-sum-gate-definition))))
 
 
 


### PR DESCRIPTION
add a new `BLOCH` gate for specifying a Bloch-sphere rotation (useful for typing random 1q unitaries)