### PR TITLE
Teach the compiler how to compile parallel programs.

### DIFF
--- a/benchmarking/rewiring-analysis.lisp
+++ b/benchmarking/rewiring-analysis.lisp
@@ -103,14 +103,13 @@
 (defun quil-file-prefix (file)
   "Gets the information prefix for a quil file"
   (let* ((pp     (quil::read-quil-file file))
-         (used-q (quil::prog-used-qubits pp))
          (instrs (parsed-program-executable-code pp))
          (multiq (loop
                    :for inst :across instrs
                      :thereis (and (typep inst 'application)
                                    (< 1 (length (application-arguments inst)))))))
     (format nil "~4,'0Dq-~7,'0Di-~:[s~;m~]"
-            (1+ (reduce #'max used-q))
+            (quil::qubits-needed pp)
             (length instrs)
             multiq)))
 
@@ -146,9 +145,9 @@
                     (break "~A" e))
                   (return-from by-assignment (list nil nil 1)))))
            (let* ((progm (get-prog prog-source chip))
-                  (max-needed (apply #'max (quil::prog-used-qubits progm))))
-             (when (< max-needed
-                      (quil::chip-spec-n-qubits chip))
+                  (max-needed (qubits-needed progm)))
+             (when (<= max-needed
+                       (quil::chip-spec-n-qubits chip))
                (funcall assn (lambda ()
                                (multiple-value-list
                                 (compiler-hook (get-prog prog-source chip) chip :destructive t))))))))

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -120,7 +120,8 @@
                               :components ((:file "quil-backend")))))
                (:module "addresser"
                 :serial t
-                :components ((:file "rewiring")
+                :components ((:file "conditions")
+                             (:file "rewiring")
                              (:file "initial-rewiring")
                              (:file "logical-schedule")
                              (:file "outgoing-schedule")

--- a/src/addresser/1q-queues.lisp
+++ b/src/addresser/1q-queues.lisp
@@ -120,7 +120,7 @@ following swaps."
       (unless physical
         ;; TODO: Should we try to pick the best one?
         (setf physical (loop
-                         :for physical :in (find-physical-component state qubit)
+                         :for physical :in (find-physical-component-in-state state qubit)
                          :unless (apply-rewiring-p2l working-l2p physical)
                            :return physical))
         (rewiring-assign working-l2p qubit physical))

--- a/src/addresser/1q-queues.lisp
+++ b/src/addresser/1q-queues.lisp
@@ -115,12 +115,12 @@ following swaps."
 (defun flush-1q-instructions-after-wiring (state qubit)
   "Flush the 1Q queue for QUBIT after potentially assigning it to a physical location."
   (check-type state addresser-state)
-  (with-slots (working-l2p chip-sched qubit-cc 1q-queues) state
+  (with-slots (working-l2p chip-sched 1q-queues) state
     (let ((physical (apply-rewiring-l2p working-l2p qubit)))
       (unless physical
         ;; TODO: Should we try to pick the best one?
         (setf physical (loop
-                         :for physical :in qubit-cc
+                         :for physical :in (find-physical-component state qubit)
                          :unless (apply-rewiring-p2l working-l2p physical)
                            :return physical))
         (rewiring-assign working-l2p qubit physical))

--- a/src/addresser/addresser-common.lisp
+++ b/src/addresser/addresser-common.lisp
@@ -573,7 +573,7 @@ If DRY-RUN, this returns T as soon as it finds an instruction it can handle."
             "Qubit ~a already assigned" logical)
     (let ((best-cost (build-worst-cost state))
           (best-physical nil))
-      (dolist (physical (find-physical-component state logical))
+      (dolist (physical (find-physical-component-in-state state logical))
         (unless (or (apply-rewiring-p2l working-l2p physical)
                     (chip-spec-qubit-dead? chip-spec physical))
           (let ((cost (with-rewiring-assign working-l2p logical physical
@@ -680,9 +680,6 @@ Optional arguments:
                          (assert (> *addresser-max-swap-sequence-length* (length rewirings-tried)) ()
                                  "Too many SWAP instructions selected in a row: ~a" (length rewirings-tried))
                          (setf rewirings-tried (select-and-embed-a-permutation state rewirings-tried)))))
-          (setf (addresser-state-l2p-components state)
-                (greedy-prog-ccs-to-chip-ccs (chip-spec-live-qubit-cc chip-spec)
-                                             (instr-used-qubits-ccs instrs)))
 
           ;; build the logically parallelized schedule
           (append-instructions-to-lschedule lschedule instrs)

--- a/src/addresser/addresser-state.lisp
+++ b/src/addresser/addresser-state.lisp
@@ -15,6 +15,7 @@
                 :documentation "The working / current logical-to-physical rewiring. NOTE: This get mutated a _lot_."
                 :type rewiring)
    (l2p-components :accessor addresser-state-l2p-components
+                   :initarg :l2p-components
                    :documentation "The association of logical to physical components."
                    :type hash-table)
    (qq-distances :accessor addresser-state-qq-distances
@@ -119,12 +120,15 @@ INSTR is the \"active instruction\".
 
 ;;; Some utilities
 
-(defun find-physical-component (state logical)
-  "Uses STATE to get a physical qubit component from the logical qubit address LOGICAL."
+(defun find-physical-component-in-state (state logical)
+  (find-physical-component (addresser-state-l2p-components state) logical))
+
+(defun find-physical-component (l2p-components logical)
+  "Uses L2P-COMPONENTS to get a physical qubit component from the logical qubit address LOGICAL."
   (maphash (lambda (logical-component physical-component)
              (when (member logical logical-component)
                (return-from find-physical-component physical-component)))
-           (addresser-state-l2p-components state))
+           l2p-components)
   (error "Unable to find a physical connected component associated with the qubit ~a." logical))
 
 (defun compute-qubit-qubit-distances (chip-spec link-cost)

--- a/src/addresser/conditions.lisp
+++ b/src/addresser/conditions.lisp
@@ -1,0 +1,32 @@
+(in-package #:cl-quil)
+
+(define-condition user-program-incompatible-with-chip (serious-condition)
+  ()
+  (:documentation "This is signaled when the user program is incompatible with the chip in some way."))
+
+(define-condition chip-insufficient-qubits (user-program-incompatible-with-chip)
+  ((needed :reader chip-insufficient-qubits-needed :initarg :needed)
+   (available :reader chip-insufficient-qubits-available :initarg :available))
+  (:report (lambda (condition stream)
+             (format stream "User program incompatible with chip: qubit index ~A used and ~A available."
+                     (chip-insufficient-qubits-needed condition)
+                     (chip-insufficient-qubits-available condition)))))
+
+(define-condition naive-rewiring-crosses-chip-boundaries (user-program-incompatible-with-chip)
+  ()
+  (:report (lambda (condition stream)
+             (declare (ignore condition))
+             (format stream
+                     "User program incompatible with chip: naive rewiring crosses chip component boundaries."))))
+
+(define-condition connected-components-incompatible (user-program-incompatible-with-chip)
+  ((program-connected-components :reader incompatible-program-ccs :initarg :program-connected-components)
+   (chip-connected-components :reader incompatible-chip-ccs :initarg :chip-connected-components))
+  (:report (lambda (condition stream)
+             (format stream "User program incompatible with chip: The program ~
+    uses operations on qubits that cannot be logically mapped onto the chip ~
+    topology. This set of qubits in the program cannot be assigned to qubits on ~
+    the chip compatibly under a greedy connected component allocation scheme: ~
+    ~A. The chip has the components ~A."
+                     (incompatible-program-ccs condition)
+                     (incompatible-chip-ccs condition)))))

--- a/src/addresser/initial-rewiring.lisp
+++ b/src/addresser/initial-rewiring.lisp
@@ -95,6 +95,8 @@ impossible using that rewiring.")
                      (setf (aref connected-component-map index) component1)))))))
       (loop :for inst :across (parsed-program-executable-code parsed-prog)
             :do (typecase inst
+                  (reset-qubit
+                   (ensure-qubit-component (reset-qubit-target inst)))
                   (measurement
                    (ensure-qubit-component (measurement-qubit inst)))
                   (application

--- a/src/addresser/rewiring.lisp
+++ b/src/addresser/rewiring.lisp
@@ -52,12 +52,15 @@ INVERSE."
     ;; Store two copies of the identity mapping to start
     (init-rewiring :l2p id :p2l (copy-seq id))))
 
-(defun generate-random-rewiring (n)
-  "Generate a random rewiring of length N."
+(defun generate-random-rewiring (n l2p-components)
+  "Generate a random rewiring of length N constrained by the component mapping L2P-COMPONENTS."
   (loop
     :with rewiring := (make-rewiring n)
     :for end :downfrom n :above 1
-    :do (update-rewiring rewiring (1- end) (random end))
+    ;; when a qubit is unused, do not permute it.
+    :when (gethash n l2p-components)
+      :do (update-rewiring rewiring (1- end) (a:random-elt (find-physical-component l2p-components (1- end))))
+            
     :finally (return rewiring)))
 
 (defun copy-rewiring (rewiring)

--- a/src/chip/chip-specification.lisp
+++ b/src/chip/chip-specification.lisp
@@ -783,3 +783,13 @@ Compilers are listed in descending precedence.")
                    (15 0) (15 14) (13 14) (12 13) (12 11) (11 10) (9 10)
                    (1 0) (15 2) (3 14) (13 4) (12 5) (6 11) (7 10) (9 8))))
     (build-chip-from-digraph digraph :architecture ':cnot)))
+
+(defun build-disconnected-chip (n-qubits)
+  "Create a CHIP-SPECIFICATION with no multi-qubit operations."
+  (let ((chip-spec (make-chip-specification
+                    :generic-rewriting-rules (coerce (global-rewriting-rules) 'vector))))
+    (install-generic-compilers chip-spec ':cz)
+    (dotimes (j n-qubits)
+      (adjoin-hardware-object (build-qubit j :type '(:RZ :X/2 :MEASURE)) chip-spec))
+    (warm-hardware-objects chip-spec)
+    chip-spec))

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -203,225 +203,228 @@ Returns a value list: (processed-program, of type parsed-program
     (check-protoquil-program parsed-program))
 
   ;; now we walk the CFG associated to the program
-  (let* ((initial-rewiring (prog-initial-rewiring parsed-program chip-specification
-                                                  :type rewiring-type))
-         (cfg (program-cfg parsed-program :dce t))
-         ;; this is a list of pairs (block-to-be-traversed registrant)
-         (block-stack (list (list (entry-point cfg) nil)))
-         (topological-swaps 0)
-         (unpreserved-duration 0))
+  (multiple-value-bind (initial-rewiring l2p-components)
+      (prog-initial-rewiring parsed-program chip-specification
+                             :type rewiring-type)
+    (let* ((cfg (program-cfg parsed-program :dce t))
+           ;; this is a list of pairs (block-to-be-traversed registrant)
+           (block-stack (list (list (entry-point cfg) nil)))
+           (topological-swaps 0)
+           (unpreserved-duration 0))
 
-    ;; In any rewiring scheme a preserved block must not touch dead
-    ;; qubits.
-    (check-preserved-blocks-skip-dead-qubits cfg chip-specification)
+      ;; In any rewiring scheme a preserved block must not touch dead
+      ;; qubits.
+      (check-preserved-blocks-skip-dead-qubits cfg chip-specification)
 
-    (let ((*print-pretty* nil))
-      (format-noise "COMPILER-HOOK: initial rewiring ~A" initial-rewiring))
+      (let ((*print-pretty* nil))
+        (format-noise "COMPILER-HOOK: initial rewiring ~A" initial-rewiring))
 
-    ;; if we are expecting to manipulate protoquil, we segment the program-final
-    ;; sequence of MEASURE instructions out into a separate CFG block, so that
-    ;; the greedy addresser doesn't try to move them forward.
-    (when protoquil
-      (let (final-blk
-            (instrs-measures nil)
-            (instrs-rest nil)
-            (new-final-blk (make-instance 'basic-block)))
-        ;; find the exit block
-        (dolist (blk (cfg-blocks cfg))
-          (when (typep (outgoing blk) 'terminating-edge)
-            (setf final-blk blk)))
-        ;; segments its instructions into the MEASURES and the non-MEASURES
-        (loop :for instr :across (basic-block-code final-blk)
-              :if (typep instr 'measure)
-                :do (push instr instrs-measures)
-              :else
-                :do (push instr instrs-rest))
-        ;; store its non-MEASURE instructions back into the block
-        (setf (basic-block-code final-blk) (coerce (nreverse instrs-rest) 'vector))
-        ;; store its MEASURE instructions into the cordoned-off block
-        (setf (basic-block-code new-final-blk) (coerce (nreverse instrs-measures) 'vector))
-        ;; place the new block in the CFG and re-link them
-        (push new-final-blk (cfg-blocks cfg))
-        (link-blocks new-final-blk terminating-edge)
-        (link-blocks final-blk (unconditional-edge new-final-blk))))
+      ;; if we are expecting to manipulate protoquil, we segment the program-final
+      ;; sequence of MEASURE instructions out into a separate CFG block, so that
+      ;; the greedy addresser doesn't try to move them forward.
+      (when protoquil
+        (let (final-blk
+              (instrs-measures nil)
+              (instrs-rest nil)
+              (new-final-blk (make-instance 'basic-block)))
+          ;; find the exit block
+          (dolist (blk (cfg-blocks cfg))
+            (when (typep (outgoing blk) 'terminating-edge)
+              (setf final-blk blk)))
+          ;; segments its instructions into the MEASURES and the non-MEASURES
+          (loop :for instr :across (basic-block-code final-blk)
+                :if (typep instr 'measure)
+                  :do (push instr instrs-measures)
+                :else
+                  :do (push instr instrs-rest))
+          ;; store its non-MEASURE instructions back into the block
+          (setf (basic-block-code final-blk) (coerce (nreverse instrs-rest) 'vector))
+          ;; store its MEASURE instructions into the cordoned-off block
+          (setf (basic-block-code new-final-blk) (coerce (nreverse instrs-measures) 'vector))
+          ;; place the new block in the CFG and re-link them
+          (push new-final-blk (cfg-blocks cfg))
+          (link-blocks new-final-blk terminating-edge)
+          (link-blocks final-blk (unconditional-edge new-final-blk))))
 
-    ;; these local functions describe how we traverse / modify the CFG.
-    (labels
-        ;; this function introduces a new block that cajoles the compiler into
-        ;; introducing rewiring SWAPs to match the exit/enter rewires across
-        ;; a jump REGISTRANT --> BLK
-        ((edge-to-rewiring-block (blk registrant target-rewiring)
-           (let* ((pseudoinstruction (make-instance 'application-force-rewiring
-                                                    :target target-rewiring))
-                  (fresh-block (make-instance 'basic-block
-                                              :code (make-array 1 :initial-element pseudoinstruction)
-                                              :incoming (list registrant)
-                                              :outgoing (unconditional-edge blk))))
-             ;; push it into the CFG
-             (push fresh-block (cfg-blocks cfg))
-             ;; update the target's parents
-             (setf (incoming blk)
-                   (list* fresh-block (remove registrant (incoming blk))))
-             ;; and update the source's outgoing edge
-             (setf (outgoing registrant)
-                   (redirect-edge blk fresh-block (outgoing registrant)))
-             ;; try again, but with this new jump
-             (push (list fresh-block registrant) block-stack)
-             (format-noise "COMPILER-HOOK: Introduced ~A to deal with the rewiring."
-                           (basic-block-name fresh-block))))
+      ;; these local functions describe how we traverse / modify the CFG.
+      (labels
+          ;; this function introduces a new block that cajoles the compiler into
+          ;; introducing rewiring SWAPs to match the exit/enter rewires across
+          ;; a jump REGISTRANT --> BLK
+          ((edge-to-rewiring-block (blk registrant target-rewiring)
+             (let* ((pseudoinstruction (make-instance 'application-force-rewiring
+                                                      :target target-rewiring))
+                    (fresh-block (make-instance 'basic-block
+                                                :code (make-array 1 :initial-element pseudoinstruction)
+                                                :incoming (list registrant)
+                                                :outgoing (unconditional-edge blk))))
+               ;; push it into the CFG
+               (push fresh-block (cfg-blocks cfg))
+               ;; update the target's parents
+               (setf (incoming blk)
+                     (list* fresh-block (remove registrant (incoming blk))))
+               ;; and update the source's outgoing edge
+               (setf (outgoing registrant)
+                     (redirect-edge blk fresh-block (outgoing registrant)))
+               ;; try again, but with this new jump
+               (push (list fresh-block registrant) block-stack)
+               (format-noise "COMPILER-HOOK: Introduced ~A to deal with the rewiring."
+                             (basic-block-name fresh-block))))
 
-         (touch-preserved-block (blk)
-           ;; if so, then we don't have any business compiling it. treat
-           ;; it as marked, with the identity rewiring on both ends,
-           ;; and proceed
-           (setf (basic-block-in-rewiring blk) (make-rewiring (chip-spec-n-qubits chip-specification)))
-           (setf (basic-block-out-rewiring blk) (make-rewiring (chip-spec-n-qubits chip-specification)))
-           (change-class blk 'basic-block))
+           (touch-preserved-block (blk)
+             ;; if so, then we don't have any business compiling it. treat
+             ;; it as marked, with the identity rewiring on both ends,
+             ;; and proceed
+             (setf (basic-block-in-rewiring blk) (make-rewiring (chip-spec-n-qubits chip-specification)))
+             (setf (basic-block-out-rewiring blk) (make-rewiring (chip-spec-n-qubits chip-specification)))
+             (change-class blk 'basic-block))
 
-         (touch-unpreserved-block (blk registrant)
-           ;; actually process this block
-           (multiple-value-bind (chip-schedule initial-l2p final-l2p)
-               (do-greedy-addressing
-                   (make-instance *default-addresser-state-class*
-                                  :chip-spec chip-specification
-                                  :initial-l2p (if registrant
-                                                   (basic-block-in-rewiring blk)
-                                                   initial-rewiring))
-                 (coerce (basic-block-code blk) 'list)
-                 :initial-rewiring (if registrant
-                                       (basic-block-in-rewiring blk)
-                                       initial-rewiring)
-                 :use-free-swaps (null registrant))
-             (let* ((duration (chip-schedule-duration chip-schedule))
-                    (straight-line-quil (chip-schedule-to-straight-quil chip-schedule))
-                    (local-topological-swaps (count-if #'swap-application-p straight-line-quil))
-                    (fully-native-quil (expand-to-native-instructions straight-line-quil chip-specification))
-                    (processed-quil fully-native-quil))
-               (dotimes (n *compressor-passes*)
-                 (format-noise "COMPILER-HOOK: Compressing, pass ~D/~D." (1+ n) *compressor-passes*)
-                 (setf processed-quil
-                       (compress-instructions processed-quil chip-specification
-                                              :protoquil (null registrant))))
-               ;; we're done processing. store the results back into the CFG block.
-               (setf (basic-block-code blk) processed-quil)
-               (setf (basic-block-in-rewiring blk) initial-l2p)
-               (setf (basic-block-out-rewiring blk) final-l2p)
-               (incf topological-swaps local-topological-swaps)
-               (incf unpreserved-duration duration)
-               (format-noise "COMPILER-HOOK: Done processing block ~A." (basic-block-name blk)))))
+           (touch-unpreserved-block (blk registrant)
+             ;; actually process this block
+             (multiple-value-bind (chip-schedule initial-l2p final-l2p)
+                 (do-greedy-addressing
+                     (make-instance *default-addresser-state-class*
+                                    :chip-spec chip-specification
+                                    :l2p-components l2p-components
+                                    :initial-l2p (if registrant
+                                                     (basic-block-in-rewiring blk)
+                                                     initial-rewiring))
+                   (coerce (basic-block-code blk) 'list)
+                   :initial-rewiring (if registrant
+                                         (basic-block-in-rewiring blk)
+                                         initial-rewiring)
+                   :use-free-swaps (null registrant))
+               (let* ((duration (chip-schedule-duration chip-schedule))
+                      (straight-line-quil (chip-schedule-to-straight-quil chip-schedule))
+                      (local-topological-swaps (count-if #'swap-application-p straight-line-quil))
+                      (fully-native-quil (expand-to-native-instructions straight-line-quil chip-specification))
+                      (processed-quil fully-native-quil))
+                 (dotimes (n *compressor-passes*)
+                   (format-noise "COMPILER-HOOK: Compressing, pass ~D/~D." (1+ n) *compressor-passes*)
+                   (setf processed-quil
+                         (compress-instructions processed-quil chip-specification
+                                                :protoquil (null registrant))))
+                 ;; we're done processing. store the results back into the CFG block.
+                 (setf (basic-block-code blk) processed-quil)
+                 (setf (basic-block-in-rewiring blk) initial-l2p)
+                 (setf (basic-block-out-rewiring blk) final-l2p)
+                 (incf topological-swaps local-topological-swaps)
+                 (incf unpreserved-duration duration)
+                 (format-noise "COMPILER-HOOK: Done processing block ~A." (basic-block-name blk)))))
 
-         (touch-reset-block (blk)
-           ;; actually process this block
-           (multiple-value-bind (chip-schedule initial-l2p final-l2p)
-               (do-greedy-addressing
-                   (make-instance *default-addresser-state-class*
-                                  :chip-spec chip-specification
-                                  :initial-l2p (prog-initial-rewiring parsed-program chip-specification
-                                                                      :type rewiring-type))
-                 (coerce (basic-block-code blk) 'list)
-                 :initial-rewiring (prog-initial-rewiring parsed-program chip-specification
-                                                          :type rewiring-type))
-             (let* ((duration (chip-schedule-duration chip-schedule))
-                    (straight-line-quil (chip-schedule-to-straight-quil chip-schedule))
-                    (local-topological-swaps (count-if #'swap-application-p straight-line-quil))
-                    (fully-native-quil (expand-to-native-instructions straight-line-quil chip-specification))
-                    (processed-quil fully-native-quil))
-               (dotimes (n *compressor-passes*)
-                 (format-noise "COMPILER-HOOK: Compressing, pass ~D/~D." (1+ n) *compressor-passes*)
-                 (setf processed-quil
-                       (compress-instructions processed-quil chip-specification
-                                              :protoquil t)))
-               ;; we're done processing. store the results back into the CFG block.
-               (setf (basic-block-code blk) processed-quil)
-               (setf (basic-block-in-rewiring blk) initial-l2p)
-               (setf (basic-block-out-rewiring blk) final-l2p)
-               (incf topological-swaps local-topological-swaps)
-               (incf unpreserved-duration duration)
-               (format-noise "COMPILER-HOOK: Done processing block ~A." (basic-block-name blk)))))
+           (touch-reset-block (blk)
+             ;; actually process this block
+             (multiple-value-bind (chip-schedule initial-l2p final-l2p)
+                 (do-greedy-addressing
+                     (make-instance *default-addresser-state-class*
+                                    :chip-spec chip-specification
+                                    :l2p-components l2p-components
+                                    :initial-l2p (prog-initial-rewiring parsed-program chip-specification
+                                                                        :type rewiring-type))
+                   (coerce (basic-block-code blk) 'list)
+                   :initial-rewiring (prog-initial-rewiring parsed-program chip-specification
+                                                            :type rewiring-type))
+               (let* ((duration (chip-schedule-duration chip-schedule))
+                      (straight-line-quil (chip-schedule-to-straight-quil chip-schedule))
+                      (local-topological-swaps (count-if #'swap-application-p straight-line-quil))
+                      (fully-native-quil (expand-to-native-instructions straight-line-quil chip-specification))
+                      (processed-quil fully-native-quil))
+                 (dotimes (n *compressor-passes*)
+                   (format-noise "COMPILER-HOOK: Compressing, pass ~D/~D." (1+ n) *compressor-passes*)
+                   (setf processed-quil
+                         (compress-instructions processed-quil chip-specification
+                                                :protoquil t)))
+                 ;; we're done processing. store the results back into the CFG block.
+                 (setf (basic-block-code blk) processed-quil)
+                 (setf (basic-block-in-rewiring blk) initial-l2p)
+                 (setf (basic-block-out-rewiring blk) final-l2p)
+                 (incf topological-swaps local-topological-swaps)
+                 (incf unpreserved-duration duration)
+                 (format-noise "COMPILER-HOOK: Done processing block ~A." (basic-block-name blk)))))
 
-         (process-block (blk registrant)
-           ;; if this block is expecting a rewiring, we should make sure the
-           ;; exit/enter rewirings match.
-           (when (and registrant
-                      (not (typep blk 'reset-block))
-                      (or (basic-block-in-rewiring blk)
-                          (typep blk 'preserved-block)))
-             ;; compare incoming and outgoing l2ps.
-             (let ((final-l2p (basic-block-out-rewiring registrant))
-                   (initial-l2p (if (typep blk 'preserved-block)
-                                    (make-rewiring (chip-spec-n-qubits chip-specification))
-                                    (basic-block-in-rewiring blk))))
-               (format-noise "COMPILER-HOOK: Matching rewiring from ~A (~A) to ~A (~A)."
-                             (basic-block-name registrant)
-                             final-l2p
+           (process-block (blk registrant)
+             ;; if this block is expecting a rewiring, we should make sure the
+             ;; exit/enter rewirings match.
+             (when (and registrant
+                        (not (typep blk 'reset-block))
+                        (or (basic-block-in-rewiring blk)
+                            (typep blk 'preserved-block)))
+               ;; compare incoming and outgoing l2ps.
+               (let ((final-l2p (basic-block-out-rewiring registrant))
+                     (initial-l2p (if (typep blk 'preserved-block)
+                                      (make-rewiring (chip-spec-n-qubits chip-specification))
+                                      (basic-block-in-rewiring blk))))
+                 (format-noise "COMPILER-HOOK: Matching rewiring from ~A (~A) to ~A (~A)."
+                               (basic-block-name registrant)
+                               final-l2p
+                               (basic-block-name blk)
+                               initial-l2p)
+                 ;; if they're the same, proceed with analyzing the jump
+                 (unless (equalp final-l2p initial-l2p)
+                   (return-from process-block
+                     (edge-to-rewiring-block blk registrant initial-l2p)))))
+
+             ;; the source's exit rewiring now matches the target's entry rewiring.
+             ;; if this block has already been visited, skip it.
+             (when (basic-block-in-rewiring blk)
+               (return-from process-block))
+
+             (let ((*print-pretty* nil))
+               (format-noise "COMPILER-HOOK: Visiting ~A for the first time, coming from ~A (~A)."
                              (basic-block-name blk)
-                             initial-l2p)
-               ;; if they're the same, proceed with analyzing the jump
-               (unless (equalp final-l2p initial-l2p)
-                 (return-from process-block
-                   (edge-to-rewiring-block blk registrant initial-l2p)))))
+                             (and registrant (basic-block-name registrant))
+                             (and registrant (basic-block-out-rewiring registrant))))
+             ;; set the block-initial-l2p, forced by the previous block
+             (when registrant
+               (setf (basic-block-in-rewiring blk)
+                     (basic-block-out-rewiring registrant)))
+             ;; add the block's children to the traversal stack
+             (adt:match outgoing-edge (outgoing blk)
+                        ((conditional-edge _ true-target false-target)
+                         (push (list true-target blk) block-stack)
+                         (push (list false-target blk) block-stack))
+                        ((unconditional-edge target)
+                         (push (list target blk) block-stack))
+                        (terminating-edge nil))
 
-           ;; the source's exit rewiring now matches the target's entry rewiring.
-           ;; if this block has already been visited, skip it.
-           (when (basic-block-in-rewiring blk)
-             (return-from process-block))
+             ;; now fork based on whether the block is PRESERVEd.
+             ;; note that touch-* will set block-initial-l2p, which indicates the block has been visited
+             (typecase blk
+               (preserved-block
+                (touch-preserved-block blk))
+               (reset-block
+                (touch-reset-block blk))
+               (otherwise
+                (touch-unpreserved-block blk registrant))))
 
-           (let ((*print-pretty* nil))
-             (format-noise "COMPILER-HOOK: Visiting ~A for the first time, coming from ~A (~A)."
-                           (basic-block-name blk)
-                           (and registrant (basic-block-name registrant))
-                           (and registrant (basic-block-out-rewiring registrant))))
-           ;; set the block-initial-l2p, forced by the previous block
-           (when registrant
-             (setf (basic-block-in-rewiring blk)
-                   (basic-block-out-rewiring registrant)))
-           ;; add the block's children to the traversal stack
-           (adt:match outgoing-edge (outgoing blk)
-             ((conditional-edge _ true-target false-target)
-              (push (list true-target blk) block-stack)
-              (push (list false-target blk) block-stack))
-             ((unconditional-edge target)
-              (push (list target blk) block-stack))
-             (terminating-edge nil))
+           ;; this is the main loop that pushes through the CFG
+           (exhaust-stack ()
+             (loop :until (endp block-stack) :do
+               (apply #'process-block (pop block-stack)))))
 
-           ;; now fork based on whether the block is PRESERVEd.
-           ;; note that touch-* will set block-initial-l2p, which indicates the block has been visited
-           (typecase blk
-             (preserved-block
-              (touch-preserved-block blk))
-             (reset-block
-              (touch-reset-block blk))
-             (otherwise
-              (touch-unpreserved-block blk registrant))))
+        ;; kick off the traversal
+        (exhaust-stack)
 
-         ;; this is the main loop that pushes through the CFG
-         (exhaust-stack ()
-           (loop :until (endp block-stack) :do
-             (apply #'process-block (pop block-stack)))))
+        ;; one more pass of CFG collapse
+        (simplify-cfg cfg)
 
-      ;; kick off the traversal
-      (exhaust-stack)
-
-      ;; one more pass of CFG collapse
-      (simplify-cfg cfg)
-
-      (let ((processed-program (reconstitute-program cfg)))
-        ;; Keep global PRAGMAS in the code, at the top of the file.
-        (setf (parsed-program-executable-code processed-program)
-              (concatenate
-               'vector
-               (remove-if-not #'global-pragma-instruction-p
-                              (parsed-program-executable-code parsed-program))
-               (parsed-program-executable-code processed-program)))
-        ;; retain the old circuit and gate definitions
-        (setf (parsed-program-gate-definitions processed-program)
-              (parsed-program-gate-definitions parsed-program))
-        (setf (parsed-program-circuit-definitions processed-program)
-              (parsed-program-circuit-definitions parsed-program))
-        (setf (parsed-program-memory-definitions processed-program)
-              (parsed-program-memory-definitions parsed-program))
-        ;; ... and output the results.
-        (values
-         processed-program
-         topological-swaps
-         unpreserved-duration)))))
+        (let ((processed-program (reconstitute-program cfg)))
+          ;; Keep global PRAGMAS in the code, at the top of the file.
+          (setf (parsed-program-executable-code processed-program)
+                (concatenate
+                 'vector
+                 (remove-if-not #'global-pragma-instruction-p
+                                (parsed-program-executable-code parsed-program))
+                 (parsed-program-executable-code processed-program)))
+          ;; retain the old circuit and gate definitions
+          (setf (parsed-program-gate-definitions processed-program)
+                (parsed-program-gate-definitions parsed-program))
+          (setf (parsed-program-circuit-definitions processed-program)
+                (parsed-program-circuit-definitions parsed-program))
+          (setf (parsed-program-memory-definitions processed-program)
+                (parsed-program-memory-definitions parsed-program))
+          ;; ... and output the results.
+          (values
+           processed-program
+           topological-swaps
+           unpreserved-duration))))))

--- a/tests/addresser-tests.lisp
+++ b/tests/addresser-tests.lisp
@@ -100,3 +100,17 @@
                    (quil::chip-contiguous-subschedule-from-last-instructions
                     sched (quil::make-qubit-resource 0 2))
                    expected-subschedule))))))
+
+;;; Check that we can compile "parallel" programs onto disconnected
+;;; chip components.
+(deftest test-addresser-multiple-components ()
+  (let ((program "DECLARE ro BIT[3]
+RX(pi/2) 0
+RX(pi/2) 1
+RX(pi/2) 2
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+MEASURE 2 ro[2]"))
+    (not-signals error
+      (quil:compiler-hook (quil:parse-quil program)
+                          (quil::build-disconnected-chip 3)))))

--- a/tests/addresser-tests.lisp
+++ b/tests/addresser-tests.lisp
@@ -115,6 +115,48 @@ MEASURE 2 ro[2]"))
       (quil:compiler-hook (quil:parse-quil program)
                           (quil::build-disconnected-chip 3)))))
 
+;;; Check that the naive assignment works correctly.
+(deftest test-addresser-multiple-components-naive ()
+  (let ((program "DECLARE ro BIT[3]
+RX(pi/2) 0
+RX(pi/2) 1
+RX(pi/2) 2
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+MEASURE 2 ro[2]"))
+    (not-signals error
+      (quil:compiler-hook (quil:parse-quil program)
+                          (quil::build-disconnected-chip 3)
+                          :rewiring-type :naive))))
+
+;;; Check that greedy assignments work as well.
+(deftest test-addresser-multiple-components-greedy ()
+  (let ((program "DECLARE ro BIT[3]
+RX(pi/2) 0
+RX(pi/2) 1
+RX(pi/2) 2
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+MEASURE 2 ro[2]"))
+    (not-signals error
+      (quil:compiler-hook (quil:parse-quil program)
+                          (quil::build-disconnected-chip 3)
+                          :rewiring-type :greedy))))
+
+;; Check that we can give a random rewiring type and the compiler will satisfy the component constraints.
+(deftest test-addresser-multiple-components-explicit ()
+  (let ((program "DECLARE ro BIT[3]
+RX(pi/2) 0
+RX(pi/2) 1
+RX(pi/2) 2
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+MEASURE 2 ro[2]"))
+    (not-signals error
+      (quil:compiler-hook (quil:parse-quil program)
+                          (quil::build-disconnected-chip 3)
+                          :rewiring-type :random))))
+
 ;;; Check that we can compile a more complicated program on a more
 ;;; complicated chip, both with multiple connected components that
 ;;; cannot be matched with the identity function.

--- a/tests/compiler-hook-tests.lisp
+++ b/tests/compiler-hook-tests.lisp
@@ -421,20 +421,22 @@ MEASURE 2 ro[2]
          (chip (quil::qpu-hash-table-to-chip-specification
                 (yason:parse "
 {\"isa\":
-{\"1Q\": {\"0\": {}, \"1\": {}, \"2\": {}, \"3\": {}, \"4\": {}, \"5\": {}, \"6\": {}, \"7\": {}, \"8\": {}}, \"2Q\": {\"0-3\": {}, \"0-1\": {}, \"1-4\": {}, \"1-2\": {}, \"2-5\": {}, \"3-6\": {}, \"3-4\": {}, \"4-7\": {}, \"4-5\": {}, \"5-8\": {}, \"6-7\": {}, \"7-8\": {}}}}")))
-         (initial-rewiring (quil::prog-initial-rewiring pp chip)))
-    (multiple-value-bind (code initial final)
-        (quil::do-greedy-addressing
-            (make-instance quil::*default-addresser-state-class*
-                           :chip-spec chip
-                           :initial-l2p initial-rewiring)
-          (coerce (parsed-program-executable-code pp) 'list)
-          :use-free-swaps t)
-      (declare (ignore code))
-      (is (every #'identity (quil::rewiring-l2p initial)))
-      (is (every #'identity (quil::rewiring-p2l initial)))
-      (is (every #'identity (quil::rewiring-l2p final)))
-      (is (every #'identity (quil::rewiring-p2l final))))))
+{\"1Q\": {\"0\": {}, \"1\": {}, \"2\": {}, \"3\": {}, \"4\": {}, \"5\": {}, \"6\": {}, \"7\": {}, \"8\": {}}, \"2Q\": {\"0-3\": {}, \"0-1\": {}, \"1-4\": {}, \"1-2\": {}, \"2-5\": {}, \"3-6\": {}, \"3-4\": {}, \"4-7\": {}, \"4-5\": {}, \"5-8\": {}, \"6-7\": {}, \"7-8\": {}}}}"))))
+    (multiple-value-bind (initial-rewiring l2p-components)
+        (quil::prog-initial-rewiring pp chip)
+      (multiple-value-bind (code initial final)
+          (quil::do-greedy-addressing
+              (make-instance quil::*default-addresser-state-class*
+                             :chip-spec chip
+                             :initial-l2p initial-rewiring
+                             :l2p-components l2p-components)
+            (coerce (parsed-program-executable-code pp) 'list)
+            :use-free-swaps t)
+        (declare (ignore code))
+        (is (every #'identity (quil::rewiring-l2p initial)))
+        (is (every #'identity (quil::rewiring-p2l initial)))
+        (is (every #'identity (quil::rewiring-l2p final)))
+        (is (every #'identity (quil::rewiring-p2l final)))))))
 
 (deftest test-pragma-preserve-block ()
   (let* ((pp (parse-quil "

--- a/tests/initial-rewiring-tests.lisp
+++ b/tests/initial-rewiring-tests.lisp
@@ -81,7 +81,7 @@ HALT
                 "{\"isa\":
         {\"1Q\": {\"1\": {}, \"3\": {}},
          \"2Q\": {\"1-2\": {}, \"2-3\": {}}}}"))))
-    (signals error (compiler-hook progm chip))))
+    (signals quil::connected-components-incompatible (compiler-hook progm chip))))
 
 (deftest test-sohaib-gh-361-regression ()
   "Regression test for github issue #361."


### PR DESCRIPTION
Using disconnected components.

Previously, we only supported allocating qubits in the program onto
the single largest component, precluding parallel program compilation,
regardless of whether the QPU topology supports it. Fix this and use a
greedy allocation scheme allowing more classes of programs to get
compiled onto QPUs with multiple connected components.

Conceptually, this is as if we combined mutliple QPUs into a
"multi-core" system, and we are now scheduling quil programs to use
them intelligently.

Fixes issue #74.