### PR TITLE
various Github CI improvements for quilc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run a multi-line script
+      - name: Run a multi-line script - test-cl-quil
         run: |
-          docker build -t rigetti/quilc:${GITHUB_SHA} .
-          docker run --rm --entrypoint=make rigetti/quilc:${GITHUB_SHA} test-cl-quil
-          docker rmi rigetti/quilc:${GITHUB_SHA}
+          sudo apt install sbcl
+          mkdir -p ${HOME}/quicklisp/local-projects
+          git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/magicl.git
+          git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/qvm.git
+          make quicklisp
+          sudo make install-test-deps
+          make test-cl-quil
 
   test-quilc:
     name: Test quilc
@@ -27,9 +31,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run a multi-line script
+      - name: Run a multi-line script - test-quilc
         run: |
           sudo apt install sbcl
+          mkdir -p ${HOME}/quicklisp/local-projects
+          git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/magicl.git
+          git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/qvm.git
           make quicklisp
           sudo make install-test-deps
           make test-quilc
@@ -40,10 +47,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run a multi-line script
+      - name: Run a multi-line script - test-quilt
         run: |
           sudo apt install sbcl
+          mkdir -p ${HOME}/quicklisp/local-projects
+          git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/magicl.git
+          git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/qvm.git
           make quicklisp
           sudo make install-test-deps
           make test-quilt
-

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ dump-version-info:
 		--eval '(format t "~A ~A" (lisp-implementation-type) (lisp-implementation-version))' \
 		--eval '(print (ql-dist:find-system "alexa"))' \
 		--eval '(print (ql-dist:find-system "magicl"))' \
+		--eval '(print (ql-dist:find-system "qvm"))' \
 		--eval '(print (ql-dist:find-system "rpcq"))' \
 		--eval '(terpri)' --quit
 


### PR DESCRIPTION
Makefile
  - add QVM to systems included by target dump-version-info target

.github/workflows/test.yml:
  - unify all jobs to run the same way except for make target
  - jobs now build with latest magicl and qvm cloned from official repo

Resolves issue #772: Github CI failing in test-cl-quil due to
Quicklisp's version of magicl being too old