### PR TITLE
Preserve existing name resolution when copying gate application

### DIFF
--- a/quilc.asd
+++ b/quilc.asd
@@ -12,7 +12,8 @@
                #:split-sequence
                #:command-line-arguments
                #:yason
-               (:version #:magicl "0.7.0")
+               (:version #:magicl/core "0.9.0")
+               #:magicl/ext-lapack
                #:cl-quil
                #:cl-quil-benchmarking
                #:uiop

--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -1330,8 +1330,7 @@ N.B. This slot should not be accessed directly! Consider using GATE-APPLICATION-
                                          (application-parameters application))
                      :arguments (mapcar #'copy-instance
                                         (application-arguments application))
-                     :name-resolution (copy-instance (gate-application-resolution
-                                                      application)))
+                     :name-resolution (gate-application-resolution application))
       (make-instance 'gate-application
                      :operator (copy-instance (application-operator application))
                      :parameters (mapcar #'copy-instance


### PR DESCRIPTION
Recently @karlosz observed that for some of the quilc tests, a large amount of time was spent calling Lisp's `compile`. This appears to still be the case, but I think I've tracked it down. For *parametric programs* (which are not currently tested in the `benchmark-nq` routines we have), quilc needs to construct a map from parameter values to matrices for each gate definition being used. This is part of `gate-definition-gate` here https://github.com/quil-lang/quilc/blob/master/src/gates.lisp#L386

Although a parsed program like `RX(pi) 0; RX(pi) 1; RX(pi/2) 0` should end up with three applications, resolved to one gate definition (for "RX"), we were getting a new gate definition for every parametric gate application. The reason for this is that in the `simplify-arithmetic` pass, we were copying gate applications, and the implementation of `copy-instance` for these was deep on the name resolution.

This PR just changes that copy to be shallow for name resolution. I think this is a reasonable thing, even outside of this specific issue.

I'd be curious as to see what flame graph @karlosz is getting with this fix.