### PR TITLE
fix issue #778: Gitlab YAML file doesn't work

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,59 +1,40 @@
-include:
-  - project: rigetti/ci
-    file: pipelines/docker.gitlab-ci.yml
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"  # manually triggered via web interface
+    - if: ($CI_MERGE_REQUEST_IID || $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH)
 
-variables:
-  IMAGE: rigetti/quilc
-  GIT_SUBMODULE_STRATEGY: recursive
+.run-in-ubuntu:
+  image: ubuntu:latest
+  tags:
+    - docker
+    - linux
+  before_script:
+    - apt update
+    - apt install -y --no-install-recommends ca-certificates git sbcl make curl gcc pkg-config liblapack-dev libblas-dev libgfortran5 gfortran libffi-dev
+    - echo "$QUILC_CA_BUNDLE" > /usr/local/share/ca-certificates/my-ca.crt && update-ca-certificates
+    - mkdir -p ${HOME}/quicklisp/local-projects
+    - git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/magicl.git
+    - git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/qvm.git
+    - make quicklisp
+    - make install-test-deps
 
 test-cl-quil:
   stage: test
-  tags:
-    - github
-    - dockerd
-  only:
-    - branches
-  image: docker:stable
+  extends:
+    - .run-in-ubuntu
   script:
-    - docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
-    - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-cl-quil
-    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
-
-test-quilt:
-  stage: test
-  tags:
-    - github
-    - dockerd
-  only:
-    - branches
-  image: docker:stable
-  script:
-    - docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
-    - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-quilt
-    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
-
-test-quilec:
-  stage: test
-  tags:
-    - github
-    - dockerd
-  only:
-    - branches
-  image: docker:stable
-  script:
-    - docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
-    - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-quilec
-    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
+    - make test-cl-quil
 
 test-quilc:
   stage: test
-  tags:
-    - github
-    - dockerd
-  only:
-    - branches
-  image: docker:stable
+  extends:
+    - .run-in-ubuntu
   script:
-    - docker build -t rigetti/quilc:${CI_COMMIT_SHORT_SHA} .
-    - docker run --rm --entrypoint=make rigetti/quilc:${CI_COMMIT_SHORT_SHA} test-quilc
-    - docker rmi rigetti/quilc:${CI_COMMIT_SHORT_SHA}
+    - make test-quilc
+
+test-quilt:
+  stage: test
+  extends:
+    - .run-in-ubuntu
+  script:
+    - make test-quilt


### PR DESCRIPTION
.gitlab-ci.yml

  - This Gitlab CI file .gitlab-ci.yml had fallen into disrepair and
    disuse, so this revives it, syncs it with its Github counterpart
    .github/workflows/test.yml, and adds a bit of extra functionality.

  - Now it does the functionality of running the three cl-quil tests
    in a similar way to what's done in Github but differs a little
    because more stuff needs be done in the Ubuntu Linux instance in
    Gitlab vs. in Github. Both CI's run in something called
    "ubuntu:latest", but Github's is a VM with a lot more commonly
    needed deps preinstalled, e.g., git, whereas Gitlab runs on the
    very stripped-down Docker ubuntu:latest container. Apart from
    these setup differences, the testing code should be almost the
    same, although Gitlab permits the use of the "extends:" directive,
    which saves some repeated code.

  - This change also adds supports for the use of CA (certificate
    authority) bundles, which is needed at some sites. We introduce a
    new environment variable, QUILC_CA_BUNDLE. (The name is patterned
    after other systems that handle CA bundles, e.g., CURL_CA_BUNDLE
    for curl, etc.) If QUILC_CA_BUNDLE is set to a non-empty string,
    it should be CA bundle data, as used by Ubuntu's
    update-ca-certificates command. (See
    https://manpages.ubuntu.com/manpages/xenial/man8/update-ca-certificates.8.html
    for details.). We dump the text value of QUILC_CA_BUNDLE (possibly
    an empty string) to the file named
    /usr/local/share/ca-certificates/my-ca.crt and run command
    update-ca-certificates. (If file is empty, it has no effect.)

Resolves issue #778: Gitlab YAML file doesn't work, out of sync with
Github counterpart