### PR TITLE
Update to new SBCL librarian interface.

### DIFF
--- a/lib/src/build-image.lisp
+++ b/lib/src/build-image.lisp
@@ -1,0 +1,13 @@
+(require '#:asdf)
+
+(asdf:load-system '#:sbcl-librarian)
+(asdf:load-system '#:libquilc)
+
+(in-package #:libquilc)
+
+(sbcl-librarian:define-aggregate-library libquilc (:function-linkage "QUILC_API")
+  quilc sbcl-librarian:handles)
+
+(sbcl-librarian:build-bindings libquilc ".")
+(sbcl-librarian:build-python-bindings libquilc ".")
+(sbcl-librarian:build-core-and-die libquilc ".")

--- a/lib/src/libquilc.lisp
+++ b/lib/src/libquilc.lisp
@@ -1,8 +1,3 @@
-(require '#:asdf)
-
-(asdf:load-system '#:libquilc)
-(asdf:load-system '#:sbcl-librarian)
-
 (in-package #:libquilc)
 
 (sbcl-librarian:define-handle-type quil-program "quil_program")
@@ -17,9 +12,8 @@
 (defun compile-protoquil (parsed-program chip-specification)
   (compiler-hook parsed-program chip-specification :protoquil t))
 
-(sbcl-librarian:define-library libquilc (:error-map error-map
-                                         :function-linkage "QUILC_API"
-                                         :function-prefix "quilc_")
+(sbcl-librarian:define-api quilc (:error-map error-map
+                                  :function-prefix "quilc_")
   (:literal "/* types */")
   (:type quil-program chip-specification error-type)
   (:literal "/* functions */")
@@ -32,6 +26,3 @@
    (("chip_spec_from_isa_descriptor" quilc::lookup-isa-descriptor-for-name) chip-specification ((descriptor :string)))
    (("print_chip_spec" quil::debug-print-chip-spec) :void ((chip-spec chip-specification)))))
 
-(sbcl-librarian:build-bindings libquilc ".")
-(sbcl-librarian:build-python-bindings libquilc ".")
-(sbcl-librarian:build-core-and-die libquilc ".")

--- a/lib/tests/c/compile-protoquil.c
+++ b/lib/tests/c/compile-protoquil.c
@@ -28,9 +28,9 @@ int main(int argc, char **argv) {
     die("unable to compile program");
 
   quilc_print_program(processed_program);
-  quilc_release_handle(program);
-  quilc_release_handle(processed_program);
-  quilc_release_handle(chip_spec);
+  lisp_release_handle(program);
+  lisp_release_handle(processed_program);
+  lisp_release_handle(chip_spec);
 
   return 0;
 }

--- a/lib/tests/c/compile-quil.c
+++ b/lib/tests/c/compile-quil.c
@@ -28,9 +28,9 @@ int main(int argc, char **argv) {
     die("unable to compile program");
 
   quilc_print_program(processed_program);
-  quilc_release_handle(program);
-  quilc_release_handle(processed_program);
-  quilc_release_handle(chip_spec);
+  lisp_release_handle(program);
+  lisp_release_handle(processed_program);
+  lisp_release_handle(chip_spec);
 
   return 0;
 }

--- a/lib/tests/c/print-chip-spec.c
+++ b/lib/tests/c/print-chip-spec.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     die("unable to build chip");
 
   quilc_print_chip_spec(chip_spec);
-  quilc_release_handle(chip_spec);
+  lisp_release_handle(chip_spec);
 
   return 0;
 }

--- a/libquilc.asd
+++ b/libquilc.asd
@@ -13,4 +13,5 @@
                )
   :in-order-to ((asdf:test-op (asdf:test-op #:libquilc-tests)))
   :serial t
-  :components ((:file "package")))
+  :components ((:file "package")
+               (:file "libquilc")))


### PR DESCRIPTION
* Notably, we pull out handles into its own API so that other sbcl
librarian managed libraries can share the implementation. (And stuff
doesn't step on each other.)