### PR TITLE
Teach the "old gate definition model" about SWAP.

### DIFF
--- a/src/chip/chip-reader.lisp
+++ b/src/chip/chip-reader.lisp
@@ -244,6 +244,7 @@
                             ((null string) nil)
                             ((string= "CZ" string) ':cz)
                             ((string= "ISWAP" string) ':iswap)
+                            ((string= "SWAP" string) ':swap)
                             ((string= "CPHASE" string) ':cphase)
                             ((string= "PISWAP" string) ':piswap)
                             ((string= "XY" string) ':xy)

--- a/src/chip/chip-specification.lisp
+++ b/src/chip/chip-specification.lisp
@@ -278,7 +278,7 @@ used to specify CHIP-SPEC."
 (defun build-link (qubit0 qubit1 &key type gate-information)
   "Constructs a template link. The native gates for this link can be specified by one of two mutually exclusive means:
 
- * The TYPE keyword can consist of (lists of) :CZ, :CPHASE, :ISWAP, :PISWAP, :CNOT.  This routine constructs a table of native gates based on 'templates' associated to each of these atoms, e.g., :CZ indicates that `CZ _ _` is native for this link.
+ * The TYPE keyword can consist of (lists of) :CZ, :CPHASE, :ISWAP, :SWAP, :PISWAP, :CNOT.  This routine constructs a table of native gates based on 'templates' associated to each of these atoms, e.g., :CZ indicates that `CZ _ _` is native for this link.
 
  * The GATE-INFORMATION keyword can be used to directly supply a hash table to be installed in the GATE-INFORMATION slot on the hardware object, allowing completely custom gateset control."
   (check-type qubit0 unsigned-byte)
@@ -317,6 +317,7 @@ used to specify CHIP-SPEC."
                                            :fidelity fidelity)))))
       (dolist (data `((:cz     "CZ"     ()  (_ _) 0.95d0)
                       (:iswap  "ISWAP"  ()  (_ _) 0.97d0)
+                      (:swap   "SWAP"   ()  (_ _) 0.97d0)
                       (:cphase "CPHASE" (_) (_ _) 0.93d0)
                       (:piswap "PISWAP" (_) (_ _) 0.97d0)
                       (:xy     "XY"     (_) (_ _) 0.97d0)

--- a/tests/compilation-tests.lisp
+++ b/tests/compilation-tests.lisp
@@ -330,3 +330,25 @@ MEASURE 4 ro[3]
 MEASURE 5 ro[4]
 ")
                         (quil::build-nq-linear-chip 6))))
+
+(deftest test-swap-native-compile ()
+  "Test that SWAP can be compiled natively."
+  (let* ((chip (quil::build-8q-chip :architecture '(:cz :swap)))
+         (compiled-prog-code
+           (quil::parsed-program-executable-code
+            (quil::compiler-hook (quil::parse-quil "SWAP 0 1")
+                                 chip))))
+    (is (quil::swap-application-p (aref compiled-prog-code 0)))
+    (is (quil::haltp (aref compiled-prog-code 1)))))
+
+(deftest test-swap-native-compile-chip-reader ()
+  "Test that SWAP is recognized as a type in a chip file."
+  (let* ((chip (quil::read-chip-spec-file
+                (merge-pathnames *qpu-test-file-directory*
+                                 "swap.qpu")))
+         (compiled-prog-code
+           (quil::parsed-program-executable-code
+            (quil::compiler-hook (quil::parse-quil "SWAP 0 1")
+                                 chip))))
+    (is (quil::swap-application-p (aref compiled-prog-code 0)))
+    (is (quil::haltp (aref compiled-prog-code 1)))))

--- a/tests/qpu-test-files/swap.qpu
+++ b/tests/qpu-test-files/swap.qpu
@@ -1,0 +1,16 @@
+{
+	"metadata": {
+	    "name": "Chip with swap",
+	    "version": "0.0",
+	},
+	"isa": {
+            "metadata": {},
+	    "1Q": {
+	        "0": { "type": "Xhalves" },
+                "1": { "type": "Xhalves" },
+	    },
+	    "2Q": {
+                "0-1": { "type": ["SWAP", "CZ"] },
+            }
+	},
+}


### PR DESCRIPTION
* Teach the chip reader how to deal with it.
* Adjust a test.

This just naively translates swap instructions directly when the
object supports it.