### PR TITLE
Configure repo to not convert LF to CLRF on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lisp text eol=lf


### PR DESCRIPTION
Git's default behavior is to convert LFs to CLRFs when checking out on Windows. This breaks the tilde newline format directive on SBCL as described here: https://sourceforge.net/p/sbcl/mailman/sbcl-devel/thread/4D50C7E6.20400%40yv.org/#msg27025402

Also see https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings for details on configuring line endings in Git.

## Testing
Successfully built Quilc on Windows, eliminating compilation errors such as the this:
```lisp
; file: C:/quicklisp/local-projects/quilc/src/transformable-mixin.lisp
; in: DEFINE-CONDITION UNSATISFIED-TRANSFORM-DEPENDENCY
;     (FORMAT STREAM "Cannot transform ~A by ~A because ~A ~
;                                is a prerequisite transform."
;             (CL-QUIL.FRONTEND:UNSATISFIED-TRANSFORM-DEPENDENCY-OBJECT CONDITION)
;             (CL-QUIL.FRONTEND:UNSATISFIED-TRANSFORM-DEPENDENCY-ATTEMPTED-TRANSFORM
;              CONDITION)
;             (CL-QUIL.FRONTEND:UNSATISFIED-TRANSFORM-DEPENDENCY-NEEDED-TRANSFORM
;              CONDITION))
; 
; caught ERROR:
;   during macroexpansion of
;   (FORMATTER "Cannot transform ~A by ~A because ~A ~
;                                is a prerequisite transform.").
;   Use *BREAK-ON-SIGNALS* to intercept.
;   
;    error in FORMAT: Unknown directive (character: Return)
;     Cannot transform ~A by ~A because ~A ~
;                                is a prerequisite transform.
;
```