### PR TITLE
prefer shorter sequences during compression with decompilation

### DIFF
--- a/src/addresser/addresser-state.lisp
+++ b/src/addresser/addresser-state.lisp
@@ -166,6 +166,7 @@ INSTR is the \"active instruction\".
 
 (defun warm-up-addresser-state (state hardware-op)
   "'Warm up' the addresser STATE by iterating over each hardware object on the chip, initializing a random gate on the object and then calling HARDWARE-OP with it."
+  (format-noise "WARM-UP-ADDRESSER-STATE: Warming...")
   ;; We snag some of the addresser state here, and restore it after the loop.
   (let ((initial-l2p (addresser-state-initial-l2p state))
         (working-l2p (addresser-state-working-l2p state))
@@ -191,6 +192,7 @@ INSTR is the \"active instruction\".
                       (append-instructions-to-lschedule (addresser-state-logical-schedule state)
                                                         instrs-compressed)
                       (funcall hardware-op hw))))))
+    (format-noise "WARM-UP-ADDRESSER-STATE: Done.")
     (setf (addresser-state-initial-l2p state) initial-l2p
           (addresser-state-working-l2p state) working-l2p
           (addresser-state-logical-schedule state) lscheduler

--- a/src/addresser/fidelity-addresser.lisp
+++ b/src/addresser/fidelity-addresser.lisp
@@ -215,12 +215,14 @@
                                        &allow-other-keys)
   (declare (ignore initargs))
   ;; set up the qq-distances slot to use log-infidelity as the basic unit
+  (format-noise "INITIALIZE FIDELITY-ADDRESSER-STATE: Calculating Q-Q distances...")
   (setf (addresser-state-qq-distances instance)
         (compute-qubit-qubit-distances chip-spec
                                        (lambda (object)
                                          (if (hardware-object-dead-p object)
                                              most-positive-fixnum
                                              (- (log (swap-fidelity chip-spec object)))))))
+  (format-noise "INITIALIZE FIDELITY-ADDRESSER-STATE: Q-Q distances calculated.")
   ;; fill the cost-bounds slot
   (flet ((fill-cost-bound (hw)
            (setf (gethash hw (fidelity-addresser-state-cost-bounds instance))

--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -296,11 +296,31 @@ Returns a value list: (processed-program, of type parsed-program
                       (local-topological-swaps (count-if #'swap-application-p straight-line-quil))
                       (fully-native-quil (expand-to-native-instructions straight-line-quil chip-specification))
                       (processed-quil fully-native-quil))
+                 ;; This is useful for debugging, but can be
+                 ;; extremely, extremely noisy.
+                 #+#:ignore
+                 (progn
+                   (format-noise "COMPILER-HOOK: Finished addressing, got:")
+                   (cond
+                     ((null processed-quil)
+                      (format-noise "    *empty program*"))
+                     (t
+                      (format-noise "~{    ~/quil:instruction-fmt/~%~}" processed-quil))))
                  (dotimes (n *compressor-passes*)
                    (format-noise "COMPILER-HOOK: Compressing, pass ~D/~D." (1+ n) *compressor-passes*)
                    (setf processed-quil
                          (compress-instructions processed-quil chip-specification
                                                 :protoquil (null registrant))))
+                 ;; This is useful for debugging, but can be
+                 ;; extremely, extremely noisy.
+                 #+#:ignore
+                 (progn
+                   (format-noise "COMPILER-HOOK: Finished compressing, got:")
+                   (cond
+                     ((null processed-quil)
+                      (format-noise "    *empty program*"))
+                     (t
+                      (format-noise "~{    ~/quil:instruction-fmt/~%~}" processed-quil))))
                  ;; we're done processing. store the results back into the CFG block.
                  (setf (basic-block-code blk) processed-quil)
                  (setf (basic-block-in-rewiring blk) initial-l2p)


### PR DESCRIPTION
When we have two equal fidelities resulting from an algebraically
reduced program, and an algebraically reduced decompiled program,
prefer the one that's shorter.

Fixes issue #801.