### PR TITLE
fix permutation gate synthesis

### DIFF
--- a/src/compilers/truth-table.lisp
+++ b/src/compilers/truth-table.lisp
@@ -1,8 +1,11 @@
 ;;;; truth-table.lisp
-;;;; This file contains the data structure representation for
-;;;; manipulating boolean functions.
+;;;;
+;;;; Author: Charles Zhang
 
 (in-package #:cl-quil)
+
+;;;; This file contains the data structure representation for
+;;;; manipulating boolean functions.
 
 (defun missing-arg ()
   (error "Required argument missing."))
@@ -73,8 +76,8 @@
    (truth-table-n-vars truth-table)
    :initial-contents
    (let ((bits (truth-table-bits truth-table)))
-     (loop for k from 0 below (length bits)
-           collect (aref bits (logandc2 k (ash 1 index)))))))
+     (loop :for k :from 0 :below (length bits)
+           :collect (aref bits (logandc2 k (ash 1 index)))))))
 
 (defun truth-table-cofactor1 (truth-table index)
   "Find the 1-cofactor of the TRUTH-TABLE with respect to INDEX."
@@ -83,8 +86,8 @@
    (truth-table-n-vars truth-table)
    :initial-contents
    (let ((bits (truth-table-bits truth-table)))
-     (loop for k from 0 below (length bits)
-           collect (aref bits (logior k (ash 1 index)))))))
+     (loop :for k :from 0 :below (length bits)
+           :collect (aref bits (logior k (ash 1 index)))))))
 
 (defun truth-table-xor (truth-table1 truth-table2)
   (declare (type truth-table truth-table1 truth-table2))
@@ -103,16 +106,16 @@
   (declare (type (member -1 1) polarity))
   (let* ((new-length (max (length cube) (1+ index)))
          (new-cube (make-array new-length :initial-element 0)))
-    (loop for i from 0
-          for trit across cube
-          do (setf (aref new-cube i) trit))
+    (loop :for i :from 0
+          :for trit :across cube
+          :do (setf (aref new-cube i) trit))
     (setf (aref new-cube index) polarity)
     new-cube))
 
-;;; This algorithm applies recursively the positive Davio decomposition
-;;; which eventually leads into the PPRM representation of a
-;;; function. An ESOP (Exclusive Sum Of Products) is represented by a
-;;; list of cubes.
+;;; This algorithm applies recursively the positive Davio
+;;; decomposition which eventually leads into the PPRM representation
+;;; of a function. An ESOP (Exclusive Sum Of Products) is represented
+;;; by a list of cubes.
 (defun truth-table-esop-from-pprm (truth-table)
   "Given a truth table, return a list of cubes which when disjoined represent the PPRM representation of the boolean function encoded by TRUTH-TABLE."
   (let ((cubes (make-hash-table :test #'equalp)))

--- a/tests/permutation-tests.lisp
+++ b/tests/permutation-tests.lisp
@@ -11,28 +11,90 @@
          (matrix (magicl:zeros (list size size) :type '(complex double-float))))
     (loop :for i :from 0
           :for j :across permutation
-          :do (setf (magicl:tref matrix j i) 1))
+          :do (setf (magicl:tref matrix i j) 1))
     matrix))
+
+(defun qubits-in-computational-order (n)
+  (nreverse (coerce (a:iota n) 'vector)))
 
 (defun permutation-synthesis-as-parsed-program (permutation)
   (make-instance 'quil::parsed-program
-                 :executable-code (coerce (quil::synthesize-permutation permutation) 'vector)))
+    :executable-code (coerce (quil::synthesize-permutation
+                              permutation
+                              (qubits-in-computational-order (cl-quil.frontend::ilog2 (length permutation))))
+                             'vector)))
 
 ;;; Test that the synthesized permutation when simulated performs the
 ;;; action of the permutation.
-(deftest test-permutation-gates-logical-matrix-equivalent ()
-  (flet ((test (permutation)
-           (is (quil::operator=
-                (quil:parsed-program-to-logical-matrix
-                 (permutation-synthesis-as-parsed-program permutation)
-                 :compress-qubits nil)
-                (matrix-from-permutation permutation)))))
-    (test #(0 1))
-    (test #(1 0))
-    (test #(3 0 1 2))
-    (test #(2 0 3 1))
-    (test #(1 0 3 2))
-    (test #(0 2 3 1))
-    (test #(2 1 3 0))
-    (test #(3 1 2 0))
-    (test +prime+)))
+(defun synthesize-and-check-permutation (permutation)
+  (quil::operator=
+   (quil:parsed-program-to-logical-matrix
+    (permutation-synthesis-as-parsed-program permutation)
+    :compress-qubits nil)
+   (matrix-from-permutation permutation)))
+
+(deftest test-permutation-gates-logical-matrix-equivalent-examples ()
+  (let ((perms (list #(0 1)
+                     #(1 0)
+                     #(3 0 1 2)
+                     #(2 0 3 1)
+                     #(1 0 3 2)
+                     #(0 2 3 1)
+                     #(2 1 3 0)
+                     #(3 1 2 0)
+                     +prime+)))
+    (dolist (p perms)
+      (is (synthesize-and-check-permutation p)))))
+
+(defun cl-perm-to-vec (p)
+  (map 'vector #'1- (cl-permutation:perm-to-vector p)))
+
+(deftest test-permutation-gates-logical-matrix-equivalent-big ()
+  (loop :for i :from 1 :to 3
+        :for n := (expt 2 i)
+        :for start := (get-internal-real-time)
+        :do (format t "~&Testing permutations of dimension ~D..." n)
+            (cl-permutation:doperms (p n)
+              (is (synthesize-and-check-permutation (cl-perm-to-vec p))))
+            (format t " done [~D ms]~%" (round (* 1000 (- (get-internal-real-time) start))
+                                               internal-time-units-per-second))))
+
+(deftest test-perm-compilation-gh805 ()
+  (let* ((chip (quil::build-nq-linear-chip 3 :architecture ':cnot))
+         (orig-prog (quil::parse-quil "
+DEFGATE PERM AS PERMUTATION:
+    5, 1, 2, 6, 7, 0, 4, 3
+
+X 0
+PERM 0 1 2
+"))
+         (orig-matrix (quil:parsed-program-to-logical-matrix orig-prog))
+         (proc-prog (quil::compiler-hook orig-prog chip))
+         (proc-matrix (quil:parsed-program-to-logical-matrix proc-prog))
+         (2q-code (program-2q-instructions proc-prog)))
+    (is (quil::matrix-equals-dwim orig-matrix proc-matrix))
+    (is (every (link-nativep chip) 2q-code))))
+
+(deftest test-random-3q-perm-compilations ()
+  (flet ((perm->prog (perm)
+           (format nil "
+DEFGATE PERM AS PERMUTATION:
+    ~{~D~^, ~}
+
+X 0
+PERM 0 1 2
+"
+                   perm)))
+    (let ((chip (quil::build-nq-linear-chip 3 :architecture ':cnot))
+          (*print-pretty* nil))
+      (loop :repeat 16 :do
+        (let* ((perm (alexandria:shuffle (alexandria:iota 8)))
+               (orig-prog (quil::parse-quil (perm->prog perm)))
+               (orig-matrix (quil:parsed-program-to-logical-matrix orig-prog))
+               (proc-prog (quil::compiler-hook orig-prog chip))
+               (proc-matrix (quil:parsed-program-to-logical-matrix proc-prog))
+               (2q-code (program-2q-instructions proc-prog)))
+          (format t "    Testing compiling perm ~A...~%" perm)
+          (is (quil::matrix-equals-dwim orig-matrix proc-matrix))
+          (is (every (link-nativep chip) 2q-code)))))))
+


### PR DESCRIPTION
Perm gates were being synthesized as inverses, leading to improper
compilations.

Added a battery of new tests for checking multi-qubit perm gate
synthesis.

Fixes #805.