### PR TITLE
Bugfix: rework some of the standard gates init logic to accommodate seq gates 

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -167,7 +167,8 @@
                              (:file "fusion")
                              (:file "simplify-arithmetic")
                              (:file "validate-sequence-gate")
-                             (:file "simplification-grab-bag")))))
+                             (:file "simplification-grab-bag")))
+               (:file "initialize-standard-gates")))
 
 ;;; Contribs
 

--- a/src/gates.lisp
+++ b/src/gates.lisp
@@ -253,8 +253,8 @@
          (mapcar #'constant parameters)
          (loop :for i :from (1- n) :downto 0 :collect (qubit i)))))))))
 
-(defmethod gate-dimension ((gate sequence-gate-definition))
-  (expt 2 (length (sequence-gate-definition-arguments gate))))
+(defmethod gate-dimension ((gate sequence-gate))
+  (expt 2 (length (sequence-gate-definition-arguments (sequence-gate-gate-definition gate)))))
 
 ;;; END SEQUENCE GATE
 
@@ -382,20 +382,9 @@ The Pauli sum is recorded as a list of PAULI-TERM objects, stored in the TERMS s
 
 ;;;;;;;;;;;;;;;;;;;;;; Default Gate Definitions ;;;;;;;;;;;;;;;;;;;;;;
 
-;;; Load all of the standard gates from src/quil/stdgates.quil
-(global-vars:define-global-var **default-gate-definitions**
-    (let ((stdgates-file (asdf:system-relative-pathname
-                          "cl-quil" "src/quil/stdgates.quil")))
-      (format t "~&; loading standard gates from ~A~%" stdgates-file)
-      (let ((table (make-hash-table :test 'equal))
-            (gate-defs
-              (remove-if-not (lambda (obj) (typep obj 'gate-definition))
-                             (parse-quil-into-raw-program
-                              (a:read-file-into-string stdgates-file)))))
-        (dolist (gate-def gate-defs table)
-          (setf (gethash (gate-definition-name gate-def) table)
-                gate-def))))
-  "A table of default gate definitions, mapping string name to a GATE-DEFINITION object.")
+;;; This will be initialized to a table of default gate definitions in
+;;; initialize-standard-gates.lisp
+(defvar **default-gate-definitions**)
 
 (defun standard-gate-names ()
   "Query for the list of standard Quil gate names."

--- a/src/initialize-standard-gates.lisp
+++ b/src/initialize-standard-gates.lisp
@@ -1,0 +1,46 @@
+;;;; initialize-standard-gates.lisp
+;;;;
+;;;; Author: Parker Williams
+
+(in-package #:cl-quil.frontend)
+
+;; Some standard gates may require specialized processing that
+;; prohibits them from being defined much earlier. (For example,
+;; SEQUENCE-GATEs.) As such, the variable which refers to the standard
+;; gates is forward-declared, but only now do we supply its value.
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+
+  (defun read-standard-gates-from-file (&optional (stdgates-file (asdf:system-relative-pathname                                                                "cl-quil" "src/quil/stdgates.quil")))
+    "Produces a table of default gate definitions, mapping string name to a GATE-DEFINITION object."
+    (let* ((gate-defs
+             (remove-if-not (lambda (obj) (typep obj 'gate-definition))
+                            (parse-quil-into-raw-program
+                             (a:read-file-into-string stdgates-file))))
+           (parsed-program (make-instance 'parsed-program :executable-code #()
+                                          :memory-definitions '()
+                                          :circuit-definitions '()
+                                          :gate-definitions gate-defs)))
+
+      (resolve-objects parsed-program)
+      (validate-defgate-loops parsed-program)
+      (parsed-program-gate-definitions parsed-program)))
+
+  (defun initialize-standard-gates ()
+    (unless (boundp '**default-gate-definitions**)
+      (let ((stdgates-file (asdf:system-relative-pathname
+                            "cl-quil" "src/quil/stdgates.quil")))
+        (format t "~&; loading standard gates from ~A~%"
+                stdgates-file)
+        (setf **default-gate-definitions**
+              (let ((table (make-hash-table :test 'equal)))
+                (dolist (gate-def (read-standard-gates-from-file stdgates-file) table)
+                  (setf (gethash (gate-definition-name gate-def) table)
+                        gate-def)))))))
+
+  (initialize-standard-gates)
+  
+) ; eval-when
+
+
+

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -572,6 +572,9 @@
    #:exp-pauli-sum-gate-arguments       ; READER
    #:exp-pauli-sum-gate-terms           ; READER
 
+   #:sequence-gate                      ; CLASS
+   #:sequence-gate-gate-definition      ; READER
+   
    #:pauli-term                         ; STRUCT
    #:make-pauli-term                    ; FUNCTION
    #:pauli-term-pauli-word              ; FUNCTION


### PR DESCRIPTION
It was discovered when fiddling with some of the std gate definitions that the recent sequence gate definition validation/resolution aren't fully integrated for sequence gate definitions added to this file