### PR TITLE
Scaffolding for CL-QUIL/DISCRETE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ uninstall:
 # TEST
 ###############################################################################
 
-.PHONY: test test-cl-quil test-quilc test-quilt test-quilec test-libquilc
-test: test-cl-quil test-quilt test-quilec test-quilc test-libquilc
+.PHONY: test test-cl-quil test-quilc test-quilt test-quilec test-discrete test-libquilc
+test: test-cl-quil test-quilt test-quilec test-quilc test-discrete test-libquilc
 
 test-cl-quil:
 	$(QUICKLISP) \
@@ -142,6 +142,11 @@ test-quilec:
 	$(QUICKLISP) \
 		--eval "(ql:quickload :cl-quil/quilec-tests)" \
 		--eval "(asdf:test-system :cl-quil/quilec)"
+
+test-discrete:
+	$(QUICKLISP) \
+		--eval "(ql:quickload :cl-quil/discrete-tests)" \
+		--eval "(asdf:test-system :cl-quil/discrete)"
 
 test-ccl:
 	ccl -n --batch --load $(QUICKLISP_HOME)/setup.lisp \

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ lifting of parsing, compiling, and optimizing Quil code. The second,
 the binary `quilc` application directly, or alternatively by
 communicating with an [RPCQ](https://github.com/rigetti/rpcq/) server.
 
-Quil is the [quantum instruction language](https://arxiv.org/pdf/1608.03355.pdf) developed at
-[Rigetti Computing](https://rigetti.com). In Quil quantum algorithms are expressed using Quil's
+Quil is the [quantum instruction language](https://quil-lang.github.io/), originally developed at Rigetti Computing. In Quil quantum algorithms are expressed using Quil's
 standard gates and instructions. One can also use Quil's `DEFGATE` to
 define new non-standard gates, and `DEFCIRCUIT` to build a named circuit
 that can be referenced elsewhere in Quil code (analogous to a function
@@ -35,7 +34,7 @@ targeting the native gates specified by the ISA.
 To clone the quilc repository and its bundled submodules, run the following command:
 
 ``` shell
-git clone --recurse-submodules https://github.com/rigetti/quilc.git
+git clone --recurse-submodules https://github.com/quil-lang/quilc.git
 ```
 
 ### Building the Quil Compiler
@@ -48,10 +47,10 @@ Prerequisites to building `quilc` are:
 4. [ZeroMQ](http://zeromq.org/intro:get-the-software): Messaging library
    required by RPCQ. Development headers are required at build time.
 
-Follow [these instructions](https://github.com/rigetti/qvm/blob/master/doc/lisp-setup.md)
+Follow [these instructions](https://github.com/quil-lang/qvm/blob/master/doc/lisp-setup.md)
 to get started from scratch.
 
-One notorious dependency is [MAGICL](https://github.com/rigetti/magicl). It is available on Quicklisp,
+One notorious dependency is [MAGICL](https://github.com/quil-lang/magicl). It is available on Quicklisp,
 but requires you to install some system libraries such as BLAS, LAPACK, and libffi. Follow MAGICL's
 instructions carefully before proceeding with loading CL-QUIL or `make`ing quilc.
 
@@ -140,7 +139,7 @@ section "Running the Quil Compiler with Docker" below. Otherwise, the following 
 will walk you through how to build the compiler from source.
 
 Follow the instructions in QVM's
-[doc/lisp-setup.md](https://github.com/rigetti/qvm/blob/master/doc/lisp-setup.md) to satisfy the
+[doc/lisp-setup.md](https://github.com/quil-lang/qvm/blob/master/doc/lisp-setup.md) to satisfy the
 dependencies required to load the `CL-QUIL` library. Afterwhich, the
 library can be loaded
 
@@ -230,8 +229,8 @@ assigned host ports. You can then inspect the mapping using `docker port CONTAIN
 1. Update `VERSION.txt` and push the commit to `master`.
 2. Push a git tag `vX.Y.Z` that contains the same version number as in `VERSION.txt`.
 3. Verify that the resulting build (triggered by pushing the tag) completes successfully.
-4. Publish a [release](https://github.com/rigetti/quilc/releases) using the tag as the name.
-5. Close the [milestone](https://github.com/rigetti/quilc/milestones) associated with this release,
+4. Publish a [release](https://github.com/quil-lang/quilc/releases) using the tag as the name.
+5. Close the [milestone](https://github.com/quil-lang/quilc/milestones) associated with this release,
    and migrate incomplete issues to the next one.
 6. Update the quilc version of downstream dependencies (if applicable, see next section).
 
@@ -239,7 +238,7 @@ assigned host ports. You can then inspect the mapping using `docker port CONTAIN
 
 Currently, there are a couple different components of the Forest SDK that depend on quilc:
 
-1. [qvm](https://github.com/rigetti/qvm)
+1. [qvm](https://github.com/quil-lang/qvm)
 2. [pyquil](https://github.com/rigetti/pyquil)
 3. [forest-benchmarking](https://github.com/rigetti/forest-benchmarking)
 
@@ -261,9 +260,7 @@ make benchmark-qasm
 
 We welcome and encourage community contributions! Peruse our [guidelines for contributing](CONTRIBUTING.md)
 to get you up to speed on expectations. Once that's clear, a good place to start is the
-[good first issue](https://github.com/rigetti/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) section. If you find any bugs, please create an [issue](https://github.com/rigetti/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). If you need help
-with some code or want to discuss some technical issues, you can find us in the `#dev`
-channel on [Slack](https://rigetti-forest.slack.com/) or in the `#qlisp` channel on [freenode IRC](irc.freenode.net).
+[good first issue](https://github.com/quil-lang/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) section. If you find any bugs, please create an [issue](https://github.com/quil-lang/quilc/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 We look forward to meeting and working with you!
 
@@ -271,7 +268,7 @@ We look forward to meeting and working with you!
 
 ## SBCL 1.5.6
 
-There is [an issue](https://github.com/rigetti/quilc/issues/401) with
+There is [an issue](https://github.com/quil-lang/quilc/issues/401) with
 SBCL 1.5.6 that results in unhandled memory faults in
 `SB-VM::FUNCALLABLE-INSTANCE-TRAMP` when attempting to run quilc
 compiled with that version of SBCL. The issue was resolved with SBCL

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -4,7 +4,7 @@
 
 (asdf:defsystem #:cl-quil
   :description "A parser and optimizing compiler for the Quantum Instruction Language (Quil)."
-  :author "Robert Smith <robert@rigetti.com>, Eric Peterson <eric@rigetti.com>, Rigetti Computing"
+  :author "Robert Smith, Eric Peterson, Rigetti Computing, and Quil-Lang contributors"
   :license "Apache License 2.0 (See LICENSE.txt)"
   :version (:read-file-form "VERSION.txt")
   :pathname "src/"
@@ -215,9 +215,37 @@
                (:file "calibration-tests")
                (:file "analysis-tests")))
 
+(asdf:defsystem #:cl-quil/discrete
+  :description "Extensions to CL-QUIL to allow compilation to a discrete gate set."
+  :license "Apache License 2.0 (See LICENSE.txt)"
+  :depends-on (#:cl-quil
+               #:coalton)
+  :in-order-to ((asdf:test-op (asdf:test-op #:cl-quil/discrete-tests)))
+  :around-compile (lambda (compile)
+                    (let (#+sbcl (sb-ext:*derive-function-types* t))
+                      (funcall compile)))
+  :pathname "src/discrete/"
+  :serial t
+  :components ((:file "package")
+               (:file "discrete-chip")))
+
+(asdf:defsystem #:cl-quil/discrete-tests
+  :description "Test suite for cl-quil/discrete."
+  :license "Apache License 2.0 (See LICENSE.txt)"
+  :depends-on (#:cl-quil/discrete
+               #:fiasco)
+  :perform (asdf:test-op (o s)
+                         (uiop:symbol-call ':cl-quil.discrete-tests
+                                           '#:run-discrete-tests))
+  :pathname "tests/discrete/"
+  :serial t
+  :components ((:file "package")
+               (:file "suite")
+               (:file "tests")))
+
 (asdf:defsystem #:cl-quil/quilec
   :description "Quantum error correction toolkit."
-  :author "Juan M. Bello-Rivas <jbellorivas@rigetti.com>"
+  :author "Juan M. Bello-Rivas"
   :license "Apache License 2.0 (See LICENSE.txt)"
   :depends-on (#:alexandria
                #:cl-quil)
@@ -234,7 +262,7 @@
 
 (asdf:defsystem #:cl-quil/quilec-tests
   :description "Test suite for cl-quil/quilec."
-  :author "Juan M. Bello-Rivas <jbellorivas@rigetti.com>"
+  :author "Juan M. Bello-Rivas"
   :license "Apache License 2.0 (See LICENSE.txt)"
   :depends-on (#:cl-quil/quilec
                #:qvm

--- a/src/discrete/discrete-chip.lisp
+++ b/src/discrete/discrete-chip.lisp
@@ -1,0 +1,50 @@
+;;;; src/discrete/discrete-chip.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:cl-quil.discrete)
+
+;;; A "discrete gate set" is purposefully vague, since the definition
+;;; may change over time. For now, though, the gate set is {H, S, T,
+;;; CNOT}, sometimes known as "Clifford+T".
+
+(alexandria:define-constant +discrete-gate-names+ '("H" "S" "T" "CNOT")
+  :test 'equalp
+  :documentation "The names of the gates of the supported discrete gate set.")
+
+;;; TODO: Maybe take some q:: symbols and expose them from QUIL.SI.
+
+(defun build-discrete-qubit (q)
+  "Build a qubit hardware object numbered Q that supports the a discrete gate set and measurement."
+  (check-type q unsigned-byte)
+  (let ((obj (q::make-hardware-object :order 0)))
+    (setf (gethash (q::make-measure-binding :qubit q
+                                            :target '_)
+                   (q::hardware-object-gate-information obj))
+          (q::make-gate-record :duration 2000 :fidelity 0.90d0))
+    (setf (gethash (q::make-measure-binding :qubit '_)
+                   (q::hardware-object-gate-information obj))
+          (q::make-gate-record :duration 2000 :fidelity 0.90d0))
+    (dolist (op '("H" "S" "T"))
+      (setf (gethash (q::make-gate-binding :operator (q:named-operator op)
+                                           :parameters nil
+                                           :arguments (list q))
+                     (q::hardware-object-gate-information obj))
+            (q::make-gate-record :duration 50
+                                 :fidelity q::+near-perfect-fidelity+)))
+    obj))
+
+(defun install-discrete-link-onto-chip (chip-spec i j)
+  "Install a Clifford link between hardware objects I and J on the chip CHIP."
+  (q::install-link-onto-chip chip-spec i j :architecture ':cnot))
+
+(defun build-discrete-linear-chip (n)
+  "Build a linear array of N discrete qubits connected by a Clifford gate."
+  (let ((chip-spec (q::make-chip-specification
+                    :generic-rewriting-rules (coerce (q::global-rewriting-rules) 'simple-vector))))
+    (q::install-generic-compilers chip-spec ':cnot)
+    (loop :for q :below n
+          :do (q::adjoin-hardware-object (build-discrete-qubit q) chip-spec))
+    (dotimes (i (1- n))
+      (install-discrete-link-onto-chip chip-spec i (1+ i)))
+    (q:warm-hardware-objects chip-spec)))

--- a/src/discrete/package.lisp
+++ b/src/discrete/package.lisp
@@ -1,0 +1,13 @@
+;;;; src/discrete/package.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(defpackage #:cl-quil.discrete
+  (:use #:cl)
+  (:local-nicknames (:q :cl-quil))
+  (:export
+   #:+discrete-gate-names+              ; CONSTANT
+   #:build-discrete-qubit               ; FUNCTION
+   #:install-discrete-link-onto-chip    ; FUNCTION
+   #:build-discrete-linear-chip         ; FUNCTION
+   ))

--- a/tests/discrete/package.lisp
+++ b/tests/discrete/package.lisp
@@ -1,0 +1,9 @@
+;;;; tests/discrete/package.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(fiasco:define-test-package #:cl-quil.discrete-tests
+  (:use #:cl)
+  ;; suite.lisp
+  (:export
+   #:run-discrete-tests))

--- a/tests/discrete/suite.lisp
+++ b/tests/discrete/suite.lisp
@@ -1,0 +1,24 @@
+;;;; tests/discrete/suite.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:cl-quil.discrete-tests)
+
+(defun run-discrete-tests (&key (verbose nil) (headless nil))
+  "Run all CL-QUIL/DISCRETE tests. If VERBOSE is T, print out lots of test info. If HEADLESS is T, disable interactive debugging and quit on completion."
+  ;; Bug in Fiasco commit fe89c0e924c22c667cc11c6fc6e79419fc7c1a8b
+  (let ((fiasco::*test-run-standard-output* (make-broadcast-stream
+                                             *standard-output*))
+        (quil::*compress-carefully* t))
+    (cond
+      ((null headless)
+       (run-package-tests :package ':cl-quil.discrete-tests
+                          :verbose verbose
+                          :describe-failures t
+                          :interactive t))
+      (t
+       (let ((successp (run-package-tests :package ':cl-quil.discrete-tests
+                                          :verbose t
+                                          :describe-failures t
+                                          :interactive nil)))
+         (uiop:quit (if successp 0 1)))))))

--- a/tests/discrete/tests.lisp
+++ b/tests/discrete/tests.lisp
@@ -1,0 +1,9 @@
+;;;; tests/discrete/tests.lisp
+;;;;
+;;;; Author:
+
+(in-package #:cl-quil.discrete-tests)
+
+(deftest test-math ()
+  (is (= 2 (+ 1 1))))
+


### PR DESCRIPTION
This adds implementation and test **SCAFFOLDING** for "discrete compilation"—compilation of Quil programs to discrete gate sets—to QUILC. This does not actually contain an implementation, except for some minor defining functions.

The implementation will come later as a collaboration with other contributors. This PR is intended to help move that along by splitting the work up a bit.