### PR TITLE
Add Clifford+T compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ quilc-sdk-barebones: quilc-sdk-base
 quilc-unsafe: QUILC_UNSAFE_OPTION=--unsafe
 quilc-unsafe: quilc
 
+quilc-discrete: COALTON_ENV=release
+quilc-discrete: POST_LOAD_ASDF_SYSTEMS="cl-quil/discrete"
+quilc-discrete: quilc
+
 DOCKER_BUILD_TARGET=all
 DOCKER_TAG=rigetti/quilc:$(COMMIT_HASH)
 .PHONY: docker

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -248,7 +248,12 @@
   :description "Extensions to CL-QUIL to allow compilation to a discrete gate set."
   :license "Apache License 2.0 (See LICENSE.txt)"
   :depends-on (#:cl-quil
-               #:coalton)
+               #:cl-quil/frontend
+               #:cl-quil/chip-library
+               #:closer-mop
+               #:parse-float
+               #:coalton
+               (:feature :sbcl #:coalton/library/big-float))
   :in-order-to ((asdf:test-op (asdf:test-op #:cl-quil/discrete-tests)))
   :around-compile (lambda (compile)
                     (let (#+sbcl (sb-ext:*derive-function-types* t))
@@ -256,13 +261,45 @@
   :pathname "src/discrete/"
   :serial t
   :components ((:file "package")
-               (:file "discrete-chip")))
+               (:file "discrete-common")
+               (:file "discrete-chip")
+               (:module "numeric"
+                :serial t
+                :components ((:file "utilities")
+                             (:file "linear-algebra")
+                             (:file "naturals")
+                             (:file "modulo")
+                             (:file "interval")
+                             (:file "root2plex")
+                             (:file "cyclotomic8")
+                             (:file "dyadic")
+                             (:file "circle")))
+               (:module "operators"
+                :serial t
+                :components ((:file "utilities")
+                             (:file "mat2")
+                             (:file "sunitary2")
+                             (:file "unitary2")
+                             (:file "hadamardt")
+                             (:file "rz")
+                             (:file "c2root2")
+                             (:file "pauli")
+                             (:file "clifford")
+                             (:file "gates1")
+                             (:file "ma-normal-form")))
+               (:module "rz-approx"
+                :serial t
+                :components ((:file "candidate-generation")
+                             (:file "candidate-verification")
+                             (:file "generate-solution")))
+               (:module "compilers"
+                :serial t
+                :components ((:file "clifford-t")))))
 
 (asdf:defsystem #:cl-quil/discrete-tests
   :description "Test suite for cl-quil/discrete."
   :license "Apache License 2.0 (See LICENSE.txt)"
-  :depends-on (#:cl-quil/discrete
-               #:fiasco)
+  :depends-on (#:cl-quil/discrete #:coalton #:coalton/testing #:fiasco)
   :perform (asdf:test-op (o s)
                          (uiop:symbol-call ':cl-quil.discrete-tests
                                            '#:run-discrete-tests))
@@ -270,7 +307,8 @@
   :serial t
   :components ((:file "package")
                (:file "suite")
-               (:file "tests")))
+               (:file "rz-approx-tests")
+               (:file "compilation-tests")))
 
 (asdf:defsystem #:cl-quil/quilec
   :description "Quantum error correction toolkit."

--- a/src/discrete/README.md
+++ b/src/discrete/README.md
@@ -1,0 +1,26 @@
+# QUILC Discrete Compilation
+
+## Usage
+
+To build Quilc with this module use `make quilc-discrete` and run tests with `make test-discrete`.
+The discrete compilers will only trigger on discrete chip ISAs. An example call is:
+
+``` sh
+echo 'PRAGMA TOLERANCE "1E-4"; RZ(0.01) 0' | ./quilc -Pm --isa 4Q-cliffordt
+```
+
+The optional `TOLERANCE` pragma is specifies how close the approximation should be (this definition is intentionally left vague as specifying tolerance provides little guarantees).
+
+## Compilers
+
+### RZ Approximation
+
+  - Approximation of RZ as unitaries over Z[i,1/sqrt(2)]
+    - Reference [arXiv:1212.6253v2](https://arxiv.org/abs/1212.6253)
+    - Source: `src/discrete/rz-approx/`
+  - Decomposes unitaries representable by Clifford+T
+    - Reference: [arXiv:1206.5236](https://arxiv.org/abs/1206.5236v4)
+    - Source: `src/discrete/operators/hadamardt.lisp`
+  - Outputs as Matsumoto Amano Normal Form
+    - Reference: [arXiv:0806.3834](https://arxiv.org/abs/0806.3834)
+    - Source: `/src/discrete/operators/ma-normal-form.lisp`

--- a/src/discrete/compilers/clifford-t.lisp
+++ b/src/discrete/compilers/clifford-t.lisp
@@ -1,0 +1,77 @@
+;;;; src/discrete/compilers/clifford-t.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(in-package #:cl-quil.discrete)
+
+;;; Compilers targeting Clifford+T (i.e. H, S, T)
+
+;; Pauli to clifford expansion rules
+
+(q::define-compiler X-to-HZH
+    ((x ("X" () q)))
+  (q:inst "H" () q)
+  (q:inst "Z" () q)
+  (q:inst "H" () q))
+
+(q::define-compiler expand-Z-to-Ss
+    ((z ("Z" () q)))
+  (q:inst "S" () q)
+  (q:inst "S" () q))
+
+(q::define-compiler expand-Y-to-ZX
+    ((z ("Y" () q)))
+  (q:inst "Z" () q)
+  (q:inst "X" () q))
+
+;; RZ to Clifford+T
+
+(q::define-compiler discretize-RZ
+    ((rz ("RZ" (theta) q))
+     :output-gateset `((:operator ,(q:named-operator "H")
+                        :arguments (_))
+                       100
+                       (:operator ,(q:named-operator "S")
+                        :arguments (_))
+                       100
+                       (:operator ,(q:named-operator "T")
+                        :arguments (_))
+                       100))
+  (unless (realp theta)
+    (q::give-up-compilation))
+
+  (let* ((reduced-theta (mod theta (* 2 pi)))
+         ;; Check RZ(n pi / 4)
+         (n (find-if (lambda (x)
+                       (q::double= (* (/ x 4) pi) reduced-theta))
+                     (alexandria:iota 8)))
+         ;; Only valid up to 0.5 epsilon
+         (epsilon (min 0.5d0 *tolerance*))
+         ;; Less candidates are available for larger epsilons
+         (trials (max 1 (- 16 (floor (log epsilon 1/10)))))
+         ;; Prime checks have a 50% success rate, so 2 checks is reasonable
+         (prime-checks 2)
+         (sequence
+           (if n
+               (coalton-prelude:Some (output-T^ n))
+               (generate-maform-output-with-double
+                trials prime-checks epsilon reduced-theta))))
+    ;; Brute force if no sequence was found (extremely unlikely, but /possible/)
+    (etypecase sequence
+      (coalton-library/classes::Optional/None
+       (setf sequence (generate-maform-output-with-double
+                       64 (* 2 prime-checks) (* epsilon 99/100) reduced-theta)))
+      (coalton-library/classes::Optional/Some nil))
+
+    (etypecase sequence
+      (coalton-library/classes::Optional/None
+       ;; Almost certainly a bug if no solution is found
+       (cl:error "No RZ solution was found within ~,2E of an angle ~E "
+                 epsilon theta))
+      (coalton-library/classes::Optional/Some
+       (dolist (x (coalton-library/optional:fromSome
+                   "Could not descructure SOME." sequence))
+         (ecase x
+           (OutputGate1/Discrete-H (q:inst "H" () q))
+           (OutputGate1/Discrete-S (q:inst "S" () q))
+           (OutputGate1/Discrete-T (q:inst "T" () q))))))))

--- a/src/discrete/discrete-chip.lisp
+++ b/src/discrete/discrete-chip.lisp
@@ -1,6 +1,6 @@
 ;;;; src/discrete/discrete-chip.lisp
 ;;;;
-;;;; Author: Robert Smith
+;;;; Author: Robert Smith, A.J. Nyquist
 
 (in-package #:cl-quil.discrete)
 
@@ -14,8 +14,10 @@
 
 ;;; TODO: Maybe take some q:: symbols and expose them from QUIL.SI.
 
-(defun build-discrete-qubit (q)
-  "Build a qubit hardware object numbered Q that supports the a discrete gate set and measurement."
+(defun build-discrete-qubit (q &key (compile-fast nil))
+  "Build a qubit hardware object numbered Q that supports the a discrete gate
+set and measurement. When COMPILE-FAST, will trick quilc into skipping certain
+compilation routines."
   (check-type q unsigned-byte)
   (let ((obj (q::make-hardware-object :order 0)))
     (setf (gethash (q::make-measure-binding :qubit q
@@ -32,19 +34,31 @@
                      (q::hardware-object-gate-information obj))
             (q::make-gate-record :duration 50
                                  :fidelity q::+near-perfect-fidelity+)))
+    ;; Speed up compilation by skipping numerous expensive calls
+    ;; With such poor fidelity, quilc will still expand RZs in the end
+    (when compile-fast
+      (setf (gethash (q::make-gate-binding :operator (q:named-operator "RZ")
+                                           :parameters (list '_)
+                                           :arguments (list q))
+                     (q::hardware-object-gate-information obj))
+            (q::make-gate-record :duration 9999
+                                 :fidelity 0.1)))
     obj))
 
 (defun install-discrete-link-onto-chip (chip-spec i j)
   "Install a Clifford link between hardware objects I and J on the chip CHIP."
   (q::install-link-onto-chip chip-spec i j :architecture ':cnot))
 
-(defun build-discrete-linear-chip (n)
-  "Build a linear array of N discrete qubits connected by a Clifford gate."
+(defun build-discrete-linear-chip (n &key (compile-fast nil))
+  "Build a linear array of N discrete qubits connected by a Clifford gate. See `build-discrete-qubit' for COMPILE-FAST."
   (let ((chip-spec (q::make-chip-specification
                     :generic-rewriting-rules (coerce (q::global-rewriting-rules) 'simple-vector))))
     (q::install-generic-compilers chip-spec ':cnot)
-    (loop :for q :below n
-          :do (q::adjoin-hardware-object (build-discrete-qubit q) chip-spec))
+    (dotimes (q n)
+      (q::adjoin-hardware-object
+       (build-discrete-qubit q :compile-fast compile-fast) chip-spec))
     (dotimes (i (1- n))
       (install-discrete-link-onto-chip chip-spec i (1+ i)))
     (q:warm-hardware-objects chip-spec)))
+
+(chips:install-chip-builder "4Q-cliffordt" (lambda () (build-discrete-linear-chip 4 :compile-fast t)))

--- a/src/discrete/discrete-common.lisp
+++ b/src/discrete/discrete-common.lisp
@@ -1,0 +1,30 @@
+;;;; src/discrete/discrete-chip.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(in-package #:cl-quil.discrete)
+
+(defvar *tolerance* cl-quil.frontend::+double-comparison-threshold-loose+
+  "Holds the value of the TOLERANCE pragma.")
+
+(deftype tolerance-type ()
+  '(double-float (0d0) (1.0d0)))
+
+(cl-quil.frontend::define-pragma "TOLERANCE" pragma-tolerance
+  (:documentation "PRAGMA denoting the target precision for discrete
+compilations that take an operator U and return an approximate U'. That is, for
+any qubit v, the upper limit of the magnitude of (U - U')v. Depending on the
+simplification rules available this target may be exceeded.
+
+  - PRAGMA TOLERANCE must only occur once and before non-pragma instructions
+  - EPSILON must be greater than 0 and less than 1
+
+Expected syntax: PRAGMA TOLERANCE \"EPSILON\"")
+  (:freeform-string epsilon)
+  (:slots (tolerance tolerance-type))
+  (:initialization
+   ;; XXX: It would be nice to not have this be a global variable
+   (setf *tolerance* (parse-float:parse-float epsilon :type 'double-float))
+   (setf tolerance *tolerance*))
+  (:display-string
+   (format nil "~E" tolerance)))

--- a/src/discrete/numeric/circle.lisp
+++ b/src/discrete/numeric/circle.lisp
@@ -1,0 +1,166 @@
+;;;; src/discrete/numeric/circle.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+;;; Operations on the complex Circle group and its subgroups
+;;; (e.g. roots of unity)
+
+(coalton-toplevel
+
+  (define-class ((Group :a) => Circle :a :b)
+    "A class representing a complex unit circle."
+    (circleReal (:a -> :b))
+    (circleImag (:a -> :b))
+    (circleComplex (:a -> (Complex :b))))
+
+  (repr :transparent)
+  (define-type (Circle :a)
+    "A set of elements equal to exp(i a 2π)'."
+    (Circle :a))
+
+  (declare fromCircle (Circle :a -> :a))
+  (define (fromCircle a)
+    (match a
+      ((Circle a) a)))
+
+  (define-instance (Num :a => (Semigroup (Circle :a)))
+    (define (<> a b)
+      (match (Tuple a b)
+        ((Tuple (Circle a) (Circle b))
+         (Circle (+ a b))))))
+
+  (define-instance (Num :a => (Monoid (Circle :a)))
+    (define mempty
+      (Circle 0)))
+
+  (define-instance (Num :a => (Group (Circle :a)))
+    (define (invert a)
+      (Circle (negate (fromCircle a)))))
+
+  (define-instance ((Elementary :a) (Elementary (Complex :a)) (Complex :a)
+                    => (Circle (Circle :a) :a))
+    (define (circleReal a)
+      (sin (* (* 2 pi) (fromCircle a))))
+    (define (circleImag a)
+      (cos (* (* 2 pi) (fromCircle a))))
+    (define (circleComplex a)
+      (exp (* (* 2 pi) (complex 0 (fromCircle a))))))
+
+  (repr :transparent)
+  (define-type RootUnity8
+    "Eighth root of unity equal to exp(iπ/4)^n."
+    (RootUnity8 (Modulo #.(nat-type 8))))
+
+  (define (rootunity8->modulo8 a)
+    (match a
+      ((RootUnity8 a) a)))
+
+  (define (rootunity8->integer a)
+    (modulo->integer (rootunity8->modulo8 a)))
+
+  (define-instance (Semigroup RootUnity8)
+    (define (<> a b)
+      (match (Tuple a b)
+        ((Tuple (RootUnity8 a) (RootUnity8 b))
+         (RootUnity8 (+ a b))))))
+
+  (define-instance (Monoid RootUnity8)
+    (define mempty
+      (RootUnity8 0)))
+
+  (define-instance (Group RootUnity8)
+    (define (invert a)
+      (RootUnity8 (negate (rootunity8->modulo8 a)))))
+
+  (define-instance (Eq RootUnity8)
+    (define (== a b)
+      (match (Tuple a b)
+        ((Tuple (RootUnity8 a) (RootUnity8 b))
+         (== a b)))))
+
+  (define-instance (Hash RootUnity8)
+    (define (hash a)
+      (hash (rootunity8->modulo8 a))))
+
+  (define-instance (Circle RootUnity8 (Root2plex Dyadic))
+    ;; Sin
+    (define (circleImag a)
+      (match (rootunity8->integer a)
+           (0 0)
+           (1 (Root2plex 0 (Dyadic 1 1)))
+           (2 1)
+           (3 (Root2plex 0 (Dyadic 1 1)))
+           (4 0)
+           (5 (Root2plex 0 (Dyadic -1 1)))
+           (6 -1)
+           (7 (Root2plex 0 (Dyadic -1 1)))))
+    ;; Cos
+    (define (circleReal a)
+      (match (rootunity8->integer a)
+           (0 1)
+           (1 (Root2plex 0 (Dyadic 1 1)))
+           (2 0)
+           (3 (Root2plex 0 (Dyadic -1 1)))
+           (4 -1)
+           (5 (Root2plex 0 (Dyadic -1 1)))
+           (6 0)
+           (7 (Root2plex 0 (Dyadic 1 1)))))
+    (define (circleComplex a)
+      (complex (circleReal a) (circleImag a))))
+
+  (repr :transparent)
+  (define-type RootUnity4
+    "Fourth root of unity equal to exp(iπ/2)^n."
+    (RootUnity4 (Modulo #.(nat-type 4))))
+
+  (define (rootunity4->modulo4 a)
+    (match a
+      ((RootUnity4 a) a)))
+
+  (define (rootunity4->integer a)
+    (modulo->integer (rootunity4->modulo4 a)))
+
+  (define-instance (Semigroup RootUnity4)
+    (define (<> a b)
+      (match (Tuple a b)
+        ((Tuple (RootUnity4 a) (RootUnity4 b))
+         (RootUnity4 (+ a b))))))
+
+  (define-instance (Monoid RootUnity4)
+    (define mempty
+      (RootUnity4 0)))
+
+  (define-instance (Group RootUnity4)
+    (define (invert a)
+      (RootUnity4 (negate (rootunity4->modulo4 a)))))
+
+  (define-instance (Eq RootUnity4)
+    (define (== a b)
+      (match (Tuple a b)
+        ((Tuple (RootUnity4 a) (RootUnity4 b))
+         (== a b)))))
+
+  (define-instance (Hash RootUnity4)
+    (define (hash a)
+      (hash (rootunity4->modulo4 a))))
+
+  (define rootunity4-plus-1 (RootUnity4 0))
+  (define rootunity4-plus-i (RootUnity4 1))
+  (define rootunity4-minus-1 (RootUnity4 2))
+  (define rootunity4-minus-i (RootUnity4 3))
+
+  (define-instance (Circle RootUnity4 Integer)
+    (define (circleReal a)
+      (cond
+           ((== a rootunity4-plus-1) 1)
+           ((== a rootunity4-minus-1) -1)
+           (True 0)))
+    (define (circleImag a)
+      (cond
+           ((== a rootunity4-plus-i) 1)
+           ((== a rootunity4-minus-i) -1)
+           (True 0)))
+    (define (circleComplex a)
+      (complex (circleReal a) (circleImag a)))))

--- a/src/discrete/numeric/cyclotomic8.lisp
+++ b/src/discrete/numeric/cyclotomic8.lisp
@@ -1,0 +1,274 @@
+;;;; src/discrete/numeric/cyclotomic8.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+;;; Defines functions on the type of cyclotomic polynomials of degree 8
+
+(coalton-toplevel
+
+  (define-type (Cyclotomic8 :a)
+    "A ring R adjoin the 8th root of unity (denoted ω)
+     ω = exp(iπ/4) = (1 + i)/√2
+     R[ω] = {aω³+bω²+cω+d | a,b,c,d ∈ R}
+     Or equivalently, the cyclotomic ring of degree 8."
+    (Cyclotomic8 :a :a :a :a))
+
+  (define-instance (Functor Cyclotomic8)
+    (define (map f x)
+      (match x
+        ((Cyclotomic8 a b c d) (Cyclotomic8 (f a) (f b) (f c) (f d))))))
+
+  (declare omega-cubed-term ((Num :a) => ((Cyclotomic8 :a) -> :a)))
+  (define (omega-cubed-term p)
+    "Returns the a term in the expression aω³+bω²+cω+d."
+    (match p
+      ((Cyclotomic8 a _ _ _) a)))
+
+  (declare omega-squared-term ((Num :a) => ((Cyclotomic8 :a) -> :a)))
+  (define (omega-squared-term p)
+    "Returns the b term in the expression aω³+bω²+cω+d."
+    (match p
+      ((Cyclotomic8 _ b _ _) b)))
+
+  (declare omega-term ((Num :a) => ((Cyclotomic8 :a) -> :a)))
+  (define (omega-term p)
+    "Returns the c term in the expression aω³+bω²+cω+d."
+    (match p
+      ((Cyclotomic8 _ _ c _) c)))
+
+  (declare omega-empty-term ((Num :a) => ((Cyclotomic8 :a) -> :a)))
+  (define (omega-empty-term p)
+    "Returns the d term in the expression aω³+bω²+cω+d."
+    (match p
+      ((Cyclotomic8 _ _ _ d) d)))
+
+  (define-instance ((Eq :a) => (Eq (Cyclotomic8 :a)))
+    (define (== p q)
+      (match (Tuple p q)
+        ((Tuple (Cyclotomic8 a1 b1 c1 d1)
+                (Cyclotomic8 a2 b2 c2 d2))
+         (and (== a1 a2) (== b1 b2) (== c1 c2) (== d1 d2))))))
+
+  (define-instance ((Hash :a) => (Hash (Cyclotomic8 :a)))
+    (define (hash p)
+      (match p
+        ((Cyclotomic8 a b c d)
+         (combine-hashes
+          (combine-hashes (hash a) (hash b))
+          (combine-hashes (hash c) (hash d)))))))
+
+  (define-instance ((Num :a) => (Num (Cyclotomic8 :a)))
+    (define (+ p q)
+      (match (Tuple p q)
+        ((Tuple (Cyclotomic8 a1 b1 c1 d1)
+                (Cyclotomic8 a2 b2 c2 d2))
+         (Cyclotomic8 (+ a1 a2) (+ b1 b2) (+ c1 c2) (+ d1 d2)))))
+    (define (- p q)
+      (match (Tuple p q)
+        ((Tuple (Cyclotomic8 a1 b1 c1 d1)
+                (Cyclotomic8 a2 b2 c2 d2))
+         (Cyclotomic8 (- a1 a2) (- b1 b2) (- c1 c2) (- d1 d2)))))
+    (define (* p q)
+      (match (Tuple p q)
+        ((Tuple (Cyclotomic8 a1 b1 c1 d1)
+                (Cyclotomic8 a2 b2 c2 d2))
+         (Cyclotomic8
+          (+ (+ (* c1 b2) (* b1 c2)) (+ (* a1 d2) (* d1 a2)))
+          (+ (- (* c1 c2) (* a1 a2)) (+ (* b1 d2) (* d1 b2)))
+          (- (+ (* d1 c2) (* c1 d2)) (+ (* b1 a2) (* a1 b2)))
+          (- (- (* d1 d2) (* a1 c2)) (+ (* b1 b2) (* c1 a2)))))))
+    (define (fromInt x)
+      (Cyclotomic8 0 0 0 (fromInt x))))
+
+  (declare cyclotomic8-norm (Num :a => (Cyclotomic8 :a)-> :a))
+  (define (cyclotomic8-norm x)
+    (match x
+      ((Cyclotomic8 a b c d)
+       ;; (a^2+b^2+c^2+d^2)^2−2(a*b+b*c+c*d−d*a)^2
+       (- (^ (+ (+ (^ a 2) (^ b 2)) (+ (^ c 2) (^ d 2))) 2)
+          (* 2 (^ (+ (+ (* a b) (* b c)) (- (* c d) (* d a))) 2))))))
+
+  (declare cyclotomic8-reciprocal
+           ((Dividable :a :b) (Num :a) (Num :b)
+            => ((Cyclotomic8 :a) -> (Optional (Cyclotomic8 :b)))))
+  (define (cyclotomic8-reciprocal x)
+    (let divisor = (cyclotomic8-norm x)) ; -a^4
+    (if (== divisor 0)
+        None
+        (match x
+          ((Cyclotomic8 a b c d)
+           (let (;; d^3+2*a*c*d+b^2*d-b*c^2+a^2*b
+                 (e1 (+ (+ (+ (^ d 3) (* 2 (* a (* c d))))
+                           (- (* (^ b 2) d)
+                              (* b (^ c 2))))
+                        (* (^ a 2) b)))
+                 ;; a*d^2-2*b*c*d+c^3+a^2*c-a*b^2
+                 (e2 (- (+ (- (* a (^ d 2)) (* 2 (* b (* c d))))
+                           (+ (^ c 3)
+                              (* (^ a 2) c)))
+                        (* a (^ b 2))))
+                 ;; b*d^2-c^2*d+a^2*d-2*a*b*c+b^3
+                 (e3 (+ (+ (- (* b (^ d 2)) (* (^ c 2) d))
+                           (- (* (^ a 2) d)
+                              (* 2 (* a (* b c)))))
+                        (^ b 3)))
+                 ;; c*d^2+2*a*b*d+a*c^2-b^2*c+a^3
+                 (e4 (+ (+ (+ (* c (^ d 2)) (* 2 (* a (* b d))))
+                           (- (* a (^ c 2))
+                              (* (^ b 2) c)))
+                        (^ a 3))))
+             (Some
+              (map (fn (dividend) (general/ dividend divisor))
+                   (Cyclotomic8 (negate e2) (negate e3) (negate e4) e1))))))))
+
+  (define-instance (Reciprocable :a => Reciprocable (Cyclotomic8 :a))
+    (define (/ a b)
+      (match (cyclotomic8-reciprocal b)
+        ((Some b-recip)
+         (* (map (fn (x) (general/ x 1)) a)
+            b-recip))
+        ((None) (error "Can't divide by zero."))))
+    (define (reciprocal b)
+      (match (cyclotomic8-reciprocal b)
+        ((Some recip) recip)
+        ((None) (error "Can't divide by zero.")))))
+
+  (declare cyclotomic8-square-modulus ((Num :a)
+                                       => (Cyclotomic8 :a) -> (Root2plex :a)))
+  (define (cyclotomic8-square-modulus x)
+    "Computes XX^† in which will take a R[ω] to R[√2] "
+    (match x
+      ((Cyclotomic8 a b c d)
+       (Root2plex
+        (+ (+ (^ a 2) (^ b 2)) (+ (^ c 2) (^ d 2)))
+        (+ (- (* c d) (* a d)) (+ (* b c) (* a b)))))))
+
+  (declare eighth-root-of-unity ((Num :a) => (Cyclotomic8 :a)))
+  (define eighth-root-of-unity
+    (Cyclotomic8 0 0 1 0))
+
+  (define-instance (Into Integer (Cyclotomic8 Integer))
+    (define (into a)
+      (fromInt a)))
+
+  (define-instance (Into (Cyclotomic8 Integer) (Cyclotomic8 Fraction))
+    (define (into x)
+      (match x
+        ((Cyclotomic8 a b c d)
+         (Cyclotomic8
+          (exact/ a 1) (exact/ b 1)
+          (exact/ c 1) (exact/ d 1))))))
+
+  (define-instance ((Num :a) (Into :a (Cyclotomic8 :a))
+                    => (Into (Root2plex :a) (Cyclotomic8 :a)))
+    (define (into a)
+      (+ (into (root2-real-part a))
+         ;; (e^(iπ/4)) - (e^(3iπ/4)) = √2
+         (* (into (root2-root-part a)) (Cyclotomic8 -1 0 1 0)))))
+
+  (define-instance ((Num :a) (Into :a (Cyclotomic8 :a)) (Complex :a)
+                    => (Into (Complex :a) (Cyclotomic8 :a)))
+    (define (into a)
+      (+ (into (real-part a))
+         ;; (e^(2iπ/4)) = i
+         (* (into (imag-part a)) (Cyclotomic8 0 1 0 0)))))
+
+  (declare cyclotomic8->complex
+           ((Rational :a) (Elementary :b)
+            => (Cyclotomic8 :a) -> (Complex :b)))
+  (define (cyclotomic8->complex y)
+    ;; HACK: Big-float memory corruption of pi on certain optimzation levels
+    (let pi = (* 2 (asin 1)))
+    (match (map
+            (fn (x)
+              (fraction->reciprocable (to-fraction x)))
+            y)
+      ((Cyclotomic8 a b c d)
+       (+ (+ (.* a (cis (/ (* 3 pi) 4)))
+             (.* b (cis (/ pi 2))))
+          (+ (.* c (cis (/ pi 4)))
+             (complex d 0))))))
+
+  (define-instance ((Complex :a)
+                    => (Into (Root2plex (Complex :a)) (Cyclotomic8 :a)))
+    (define (into a)
+      (Cyclotomic8
+       ;;    (e^(iπ/4)) + (e^(3iπ/4)) = i√2
+       (- (imag-part (root2-root-part a))
+          ;; (e^(iπ/4)) - (e^(3iπ/4)) = √2
+          (real-part (root2-root-part a)))
+       ;; (e^(2iπ/4)) = i
+       (imag-part (root2-real-part a))
+       ;; (e^(iπ/4)) + (e^(3iπ/4)) = i√2
+       (+ (imag-part (root2-root-part a))
+          ;; (e^(iπ/4)) - (e^(3iπ/4)) = √2
+          (real-part (root2-root-part a)))
+       (real-part (root2-real-part a)))))
+
+  (define-instance ((Complex :a)
+                    => (Into (Complex (Root2plex :a)) (Cyclotomic8 :a)))
+    (define (into a)
+      ;; a + b√2 + (c + d√2)i
+      (Cyclotomic8
+       ;; b - d
+       (- (root2-root-part (imag-part a))
+          (root2-root-part (real-part a)))
+       ;; c
+       (root2-real-part (imag-part a))
+       ;; b + d
+       (+ (root2-root-part (imag-part a))
+          (root2-root-part (real-part a)))
+       ;; a
+       (root2-real-part (real-part a)))))
+
+  (define-instance ((Num :a) => (ExactRoot2 (Cyclotomic8 :a)))
+    (define (root2-conjugate p)
+      "Maps aω³+bω²+cω+d to -aω³+bω²-cω+d"
+      (match p
+        ((Cyclotomic8 a b c d) (Cyclotomic8 (negate a) b (negate c) d)))))
+
+  (define-instance ((Num :a) => (Dagger (Cyclotomic8 :a)))
+    (define (dagger p)
+      "Maps aω³+bω²+cω+d to -cω³-bω²-aω+d"
+      (match p
+        ((Cyclotomic8 a b c d)
+         (Cyclotomic8 (negate c) (negate b) (negate a) d)))))
+
+  (define-instance (Factorable (Cyclotomic8 Integer))
+    (define (euclid-norm a) (cyclotomic8-norm a))
+    (define (canonical-factor x)
+      (let ordered =
+        (match x
+          ((Cyclotomic8 a b c d)
+           (let abs-a = (abs a))
+           (let abs-b = (abs b))
+           (let abs-c = (abs c))
+           (let abs-d = (abs d))
+           (cond
+             ((and (and (> abs-a abs-b) (> abs-a abs-c))
+                   (> abs-a abs-d))
+              (Cyclotomic8 b c d (negate a)))
+             ((and (> abs-b abs-c) (> abs-b abs-d))
+              (Cyclotomic8 c d (negate a) (negate b)))
+             ((> abs-c abs-d)
+              (Cyclotomic8 (negate d) a b c))
+             (True x)))))
+      (if (> 0 (omega-empty-term ordered))
+          (negate ordered)
+          ordered))
+    (define (euclid-div x y)
+      ;; N(y) = σ(yy*)yy*
+      ;; x / y = σ(yy*)xy*/(N(y))
+      (let dividend =
+        (* (* x (dagger y)) (root2-conjugate (* y (dagger y)))))
+      (let divisor = (euclid-norm y))
+      (match dividend
+        ((Cyclotomic8 a b c d)
+         (Cyclotomic8 (euclid-div a divisor)
+                      (euclid-div b divisor)
+                      (euclid-div c divisor)
+                      (euclid-div d divisor)))))
+    (define (euclid-gcd a b)
+      (general-gcd a b))))

--- a/src/discrete/numeric/dyadic.lisp
+++ b/src/discrete/numeric/dyadic.lisp
@@ -1,0 +1,135 @@
+;;;; src/discrete/numeric/dyadic.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+;; Arbitrarily sized dyadic rationals
+
+(coalton-toplevel
+  (define-type Dyadic
+    "Dyadic rationals are {n/2^m | n,m∈ℤ}"
+    (Dyadic Integer Integer))
+
+  (define (dyadic-numerator d)
+    "Maps a dyadic n/2^m to n"
+    (match d
+      ((Dyadic n _) n)))
+
+  (define (dyadic-exponent d)
+    "Maps a dyadic n/2^m to m"
+    (match d
+      ((Dyadic _ k) k)))
+
+  (define (dyadic-simplify d)
+    "Simplifies the fraction formed by Dyadic"
+    ;; a / 2^k = 2^x/2^k = 1/2^(k-x) = 2^(x-k)
+    (let r = (the Fraction (into d)))
+    (match (exact-ilog 2 (denominator r))
+      ((Some k) (Dyadic (numerator r) k))
+      ((None) d)))
+
+  (define-instance (Into Dyadic Fraction)
+    (define (into a)
+      (match a
+        ((Dyadic n k)
+         (/ (fromInt n) (^^ 2 k))))))
+
+  (define-instance (Quantizable Dyadic)
+    (define (proper x)
+      (match x
+        ((Dyadic n k)
+         (match (quotRem n (^ 2 k))
+           ((Tuple q r)
+            (Tuple q (Dyadic r k)))))))
+    (define (floor x)
+      (floor (the Fraction (into x))))
+    (define (ceiling x)
+      (ceiling (the Fraction (into x)))))
+
+  (define-instance (Real Dyadic)
+    (define (real-approx a x)
+      (real-approx a (the Fraction (into x)))))
+
+  (define-instance (Rational Dyadic)
+    (define (to-fraction x) (into x))
+    (define (best-approx x) (into x)))
+
+  (declare dyadic-compare-function ((Integer -> Integer -> :a)
+                                    -> Dyadic -> Dyadic -> :a))
+  (define (dyadic-compare-function f a b)
+    (match (Tuple a b)
+      ((Tuple (Dyadic n k)
+              (Dyadic m j))
+       ;; n / 2^k `f' m / 2^j
+       ;; n 2^j `f' m 2^k
+       ;; n 2^j / 2^l `f' m 2^k / 2^l
+       ;; n 2^(j-l) `f' m 2^(k-l) where l is min(j k)
+       (progn
+         (let l = (min j k))
+         (f (bits:shift (- j l) n)
+            (bits:shift (- k l) m))))))
+
+  (define-instance (Eq Dyadic)
+    (define (== a b)
+      (dyadic-compare-function == a b)))
+
+  (define-instance (Ord Dyadic)
+    (define (<=> a b)
+      (dyadic-compare-function <=> a b)))
+
+  (define-instance (Hash Dyadic)
+    (define (hash a)
+      (match (dyadic-simplify a)
+        ((Dyadic n k)
+         (combine-hashes (hash n) (hash k))))))
+
+  (declare dyadic-group-function ((Integer -> Integer -> Integer)
+                                  -> Dyadic -> Dyadic -> Dyadic))
+  (define (dyadic-group-function f a b)
+    (match (Tuple a b)
+      ((Tuple (Dyadic n k)
+              (Dyadic m j))
+       (if (> k j)
+           (Dyadic (f n (bits:shift (- k j) m)) k)
+           (Dyadic (f (bits:shift (- j k) n) m) j)))))
+
+  (define-instance (Num Dyadic)
+    (define (+ a b)
+      (dyadic-group-function + a b))
+    (define (- a b)
+      (dyadic-group-function - a b))
+    (define (* a b)
+      (match (Tuple a b)
+        ((Tuple (Dyadic n k)
+                (Dyadic m j))
+         (Dyadic (* n m) (+ j k)))))
+    (define (fromInt x) (Dyadic x 0)))
+
+  (define-instance (Dagger Dyadic)
+    (define dagger id))
+
+  (define-instance (Into Integer Dyadic)
+    (define into fromInt))
+
+  (define-instance (Into Dyadic (Cyclotomic8 Dyadic))
+    (define (into x)
+      (Cyclotomic8 0 0 0 x)))
+
+  (define-class (Num :a => (OneHalf :a))
+    "Types with exact representations of one half"
+    (oneHalf :a))
+
+  (define-instance (OneHalf Dyadic)
+    (define oneHalf (Dyadic 1 1)))
+
+  (define-instance (OneHalf Fraction)
+    (define oneHalf (exact/ 1 2)))
+
+  (define-instance (Complex Dyadic)
+    (define (complex a b)
+      (makeComplex a b))
+    (define (real-part a)
+      (complexReal a))
+    (define (imag-part a)
+      (complexImag a))))

--- a/src/discrete/numeric/interval.lisp
+++ b/src/discrete/numeric/interval.lisp
@@ -1,0 +1,64 @@
+;;;; src/discrete/numeric/invterval.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+;;; Interval arithmetic
+
+(coalton-toplevel
+
+  (define-type (Interval :a)
+    "An interval between two points."
+    (Interval :a :a))
+
+  (declare interval-distance ((Num :a) => ((Interval :a) -> :a)))
+  (define (interval-distance s)
+    (match s
+      ((Interval x0 x1)
+       (- x1 x0))))
+
+  (declare lower ((Num :a) => ((Interval :a) -> :a)))
+  (define (lower i)
+    (match i
+      ((Interval l _) l)))
+
+  (declare upper ((Num :a) => ((Interval :a) -> :a)))
+  (define (upper i)
+    (match i
+      ((Interval _ r) r)))
+
+  (define-instance ((Num :r) => (Eq (Interval :r)))
+    (define (== x y)
+      (and (== (lower x) (lower y))
+           (== (upper y) (upper y)))))
+
+  (define-instance ((Num :a) (Ord :a) => (Num (Interval :a)))
+    (define (+ a b)
+      (Interval (+ (lower a) (lower b))
+                (+ (upper a) (upper b))))
+    (define (- a b)
+      (Interval (- (lower a) (upper b))
+                (- (upper a) (lower b))))
+    (define (* a b)
+      (let t1 = (* (upper a) (upper b)))
+      (let t2 = (* (upper a) (lower b)))
+      (let t3 = (* (lower a) (upper b)))
+      (let t4 = (* (lower a) (lower b)))
+      (Interval
+       (min (min t1 t2) (min t3 t4))
+       (max (max t1 t2) (max t3 t4))))
+    (define (fromInt a)
+      (Interval (fromInt a) (fromInt a))))
+
+  (define-instance ((Ord :r) (Num :r) => (Linear (Interval :r) :r))
+    (define (.* a i)
+      (match i
+        ((Interval l r)
+         (if (>= a 0)
+             (Interval (* a l) (* a r))
+             (Interval (* a r) (* a l)))))))
+
+  (declare interval-elem ((Num :a) (Ord :a) => (:a -> (Interval :a) -> Boolean)))
+  (define (interval-elem x interval)
+    (and (<= (lower interval) x) (<= x (upper interval)))))

--- a/src/discrete/numeric/linear-algebra.lisp
+++ b/src/discrete/numeric/linear-algebra.lisp
@@ -1,0 +1,279 @@
+;;;; src/discrete/numeric/linear-algebra.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+;;; Common classes, types, and functions for (linear) algebra code (e.g. group
+;;; actions, modules/vectors, matrices, (linear) transformations, eigenvalues).
+
+(coalton-toplevel
+
+  (define-class (Scalar :v :s)
+    "The scalar :S associated with :V where `zero-scalar' returns 0."
+    (zero-scalar (:v -> :s)))
+
+  (define-instance ((Num :s) => (Scalar (:v :s) :s))
+    (define (zero-scalar _) 0))
+
+  (define-class (Degreed :a)
+    "Anything whose dimensions can be mapped from a constant N has degree N.
+For example an N x N matrix has degree N."
+    (degree (:a -> Integer)))
+
+  (define-class ((Scalar :v :s) => (Linear :v :s))
+    "Defines scalar multiplication where (.* x (+ v u)) = (+ (.* x u) (.* x v))"
+    (.* (:s -> :v -> :v)))
+
+  (declare *. ((Linear :v :e) (Num :e) => (:v -> :e -> :v)))
+  (define (*. v s) (.* s v))
+
+  (declare ./ ((Linear :v :e) (Reciprocable :e)
+               => (:e -> :v -> :v)))
+  (define (./ s v) (.* (/ 1 s) v))
+
+  (declare /. ((Linear :v :e) (Reciprocable :e)
+               => (:v -> :e  -> :v)))
+  (define (/. v s) (./ s v))
+
+  (define-class ((Linear :v :e) => (Inner :v :e))
+    "An (indefinite) inner product that should satisfy:
+    - (<.> x y) = (<.> y x)
+    - (<.> z (+ (.* a x) (.* b y))) = (+ (*. (<.> z x) a) (*. (<.> z y) b)) "
+    (<.> (:v -> :v -> :e)))
+
+  ;; Note that normed spaces are a superset of definite inner product spaces.
+  (define-class ((Linear :v :e) => (Normed :v :e))
+    "A (indefinite) normed space that should satisify
+    - (norm (+ x y)) <= (+ (norm x) (norm y))
+    - (norm (.* s x)) = (* |s| (norm x))"
+    (norm (:v -> :e)))
+
+  (declare square-norm ((Inner :v :e) => (:v -> :e)))
+  (define (square-norm v)
+    "The canonical (indefinite) norm squared of a given inner product space for
+an element V (i.e. ǁvǁ² = 〈v,v〉). For Euclidean vectors this is the magnitude
+squared."
+    (<.> v v))
+
+  (declare canonical-norm ((Inner :v :e) (Elementary :e) => :v -> :e))
+  (define canonical-norm
+    "The canonical norm of a given inner product space for an element V (i.e.
+ǁvǁ = √〈v,v〉). For Euclidean vectors this is the magnitude. This function may
+be partial as there is no way to determine if an Inner (product) is
+positive-definite. Use `norm' for positive-definite cases."
+    (compose sqrt square-norm))
+
+  ;;; Matrices and Operators
+
+  (define-class ((Applicative :m) => (Matrix :m))
+    "A matrix; or something with a matrix representation."
+    (rows ((:m :e) -> Integer))
+    (cols ((:m :e) -> Integer))
+    (entry ((:m :e) -> Integer -> Integer -> :e))
+    (map-over-indices ((:a -> Integer -> Integer -> :b)
+                       -> (:m :a) -> (:m :b))))
+
+  (define-class (Composable :f :g :h)
+    "Generalizes composition or application where (apply f g) = fg = f∘g, f(g).
+For example if apply is matrix multiplciation, g would be a matrix representing a
+linear transformation V → U, and f may similarly be a U → V or a vector in V."
+    ;; Can be thought of two ways
+    ;;  - Convert :f into the function (:g -> :h)
+    ;;  - Eval :f of :g to return :h
+    (apply (:f -> (:g -> :h))))
+
+  (define-class (Action :a :b)
+    "An action is a closed `apply' operation."
+    (act (:a -> :b -> :b)))
+
+  (define-class ((Action :a :a) => Identity :a)
+    "The Composable identity element."
+    (identity :a))
+
+  (define-class ((Identity :a) => (Inverse :a))
+    "Satisfies (@ A (safe-inverse A)) = (Some identity) or None.
+When safe-inverse is None, inverse may error."
+    (inverse (:a -> :a))
+    (safe-inverse (:a -> (Optional :a))))
+
+  (define-instance ((Composable :f :x :x) => (Action :f :x))
+    (define (act op v)
+      ((the (:a -> :a) (apply op)) v)))
+
+  ;; Ex: (coalton (act (+ 1) 1)) = 2
+  (define-instance (Composable (Arrow :b :c) (Arrow :a :b) (Arrow :a :c))
+    (define (apply f g x) (f (g x))))
+
+  ;; Ex: (coalton (act (+ 1) (+ 1) 1)) = 3
+  (define-instance (Composable (Arrow :a :b) :a :b)
+    (define (apply f x) (f x)))
+
+  ;; Overlapping instance bug
+  ;; (define-instance (Identity (Arrow :a :a))
+  ;;   (define identity (fn (x) x)))
+
+  (declare constructor-act ((Action (:a :e) (:v :e)) => (:a :e) -> (:v :e) -> (:v :e)))
+  (define (constructor-act a v)
+    "Same as `act', but carries over constructed types."
+    (act a v))
+
+  ;; Ex: (coalton ((@ (+ 2) (+ 1)) -3)) = 0
+  (declare @ ((Action :a :a) => :a -> :a -> :a))
+  (define (@ op v)
+    "Composition forming a semigroup."
+    (act op v))
+
+  ;; Ex: (coalton (@^ (+ 1) 3 1)) = 4
+  (declare @^ ((Identity :f) => (:f -> Integer -> :f)))
+  (define (@^ f n)
+    (let ((act-rec
+            (fn (x n)
+              (if (> n 0)
+
+                  (act-rec (act f x) (- n 1)) x))))
+      (if (< n 0)
+          (error "Can't apply negative times.")
+          (act-rec identity n))))
+
+  (declare @^^ ((Inverse :a) => (:a -> Integer -> :a)))
+  (define (@^^ f n)
+    (if (< n 0)
+        (@^ (inverse f) (negate n))
+        (@^ f n)))
+
+  (declare foldable->action ((Into :a :b) (Identity :b) (Foldable :f) (Functor :f)
+                             => ((:f :a) -> :b)))
+  (define (foldable->action cts)
+    "Convert foldable (e.g. a list) with elements as actions to an action."
+    (fold @ identity (map into cts)))
+
+  (define-instance ((Composable :a :b :c)
+                    => (Composable (Optional :a) (Optional :b) (Optional :c)))
+    (define apply (liftA2 apply)))
+
+  (define-instance ((Identity :a) (Action (Optional :a) (Optional :a))
+                    => (Identity (Optional :a)))
+    (define identity (pure identity)))
+
+  (declare square-transpose ((Matrix :m) => (:m :e) -> (:m :e)))
+  (define (square-transpose m)
+    (map-over-indices
+     (fn (_ i j)
+       (entry m j i))
+     m))
+
+  (define-class (Dagger :a)
+    "Anything closed under a complex conjugate, conjugate transpose,
+Hermitian adjoint, or related involution - often notated †."
+    (dagger (:a -> :a)))
+
+  (define-instance ((Num :a) (Dagger :a) (Complex :a)
+                    => (Dagger (Complex :a)))
+    (define (dagger a)
+      "Standard complex conjugate: a + b i to a - b i"
+      ;; We dagger the argument in the case of nested complex structures
+      (complex (dagger (real-part a))
+               (dagger (negate (imag-part a))))))
+
+  (define-instance (Dagger Integer) (define (dagger a) (id a)))
+  (define-instance (Dagger Fraction) (define (dagger a) (id a)))
+  (define-instance (Dagger Single-Float) (define (dagger a) (id a)))
+  (define-instance (Dagger Double-Float) (define (dagger a) (id a)))
+  #+sbcl (define-instance (Dagger Big-Float) (define (dagger x) x))
+
+  (declare dagger-square-norm ((Dagger :a) (Num :a) => :a -> :a))
+  (define (dagger-square-norm a)
+    (* a (dagger a)))
+
+  (define-class ((Scalar :m :e) => (Det :m :e))
+    "Linear operator with a determinant."
+    (det (:m -> :e)))
+
+  (define-class ((Scalar :m :e) => (Tr :m :e))
+    "Linear operator with a trace."
+    (tr (:m -> :e)))
+
+  (declare projective-equivalence
+           ((Tr (:a :e) :e) (Action (:a :e) (:a :e))
+            (Degreed (:a :e))
+            (Dagger (:a :e)) (Num :e) (Dagger :e)
+            => ((:a :e) -> (:a :e) -> Boolean)))
+  (define (projective-equivalence m n)
+    "Checks two matrices are in the same projective class."
+    ;; sqrt(1 - |trace (m @ n^†)|/(degree m)) = 0
+    ;; 1 - |trace (m @ n^†)|/(degree m) = 0
+    ;; |trace (m @ n^†)| = (degree m)
+    ;; norm(trace (m @ n^†)) = (degree m)
+    ;; norm(trace (m @ n^†))^2 = (degree m)^2
+    (== (+ (fromInt (^ (degree m) 2)) ((the ((:a :e) -> :e) zero-scalar) m))
+        (dagger-square-norm (tr (@ m (dagger n))))))
+
+  (declare spectral-radius
+           ((Ord :b) (Elementary :b) (Eigen :a (Complex :b))
+            => :a -> :b))
+  (define (spectral-radius m)
+    "Finds the spectral radius of a complex finite matrix."
+    (match (coalton-library/list:maximum
+            (map magnitude (eigenvalues m)))
+      ((Some lambda) lambda)
+      ;; Eigenvalue of empty matrix is 0
+      ((None) 0)))
+
+  (declare spectral-distance
+           ((Ord :b) (Elementary :b) (Matrix :m)
+            (Eigen (:m (Complex :b)) (Complex :b))
+            => ((:m (Complex :b)) -> (:m (Complex :b)) -> :b)))
+  (define (spectral-distance m n)
+    (spectral-radius (liftA2 - m n)))
+
+  (declare global-phase-invariant-distance
+           ((Elementary :b) (Degreed :a) (Normed (Complex :b) :b)
+            (Identity :a) (Dagger :a) (Tr :a (Complex :b))
+            => :a -> :a -> :b))
+  (define (global-phase-invariant-distance m n)
+    "Distance between two unitaries up to a phase."
+    (sqrt (- 1 (/ ((the ((Complex :e) -> :e) norm)
+                   (the (Complex :a) (tr (@ m (dagger n)))))
+                  (fromInt (degree m))))))
+
+  (define-class ((Scalar :m :e) => (Eigen :m :e))
+    "An operator with computable lists of eigenvalues."
+    (eigenvalues (:m -> (List :e))))
+
+  (define-class ((Action :m :v) (Eigen :m :e) => (EigenLinear :m :v :e))
+    "An operator with computable lists of eigenvectors and eigenvalues."
+    (eigenvectors (:m -> (List :v)))
+    (eigenZip (:m -> (List (Tuple :e :v)))))
+
+  (define (dimensions m)
+    (Tuple (rows m) (cols m)))
+
+  (define (same-size? a b)
+    (== (dimensions a) (dimensions b)))
+
+  (define (valid-entry? m r c)
+    (and (and (< 0 r) (<= r (rows m)))
+         (and (< 0 c) (<= c (cols m)))))
+
+  (define (safe-entry m r c)
+    (if (valid-entry? m r c)
+        (Some (entry m r c))
+        None))
+
+  ;;;; Implmentations
+  ;;; Complex numbers
+
+  (define-instance ((Complex :e) (Num :e) (Num (Complex :e))
+                    => (Linear (Complex :e) :e))
+    (define (.* s v)
+      (complex (* s (real-part v)) (* s (imag-part v)))))
+
+  (define-instance ((Linear (Complex :e) :e) (Complex :e)
+                    => (Inner (Complex :e) :e))
+    (define (<.> a b)
+      (+ (* (real-part a) (real-part b)) (* (imag-part a) (imag-part b)))))
+
+  (define-instance ((Inner (Complex :f) :f) (Elementary :f)
+                    => (Normed (Complex :f) :f))
+    (define (norm x) (canonical-norm x))))

--- a/src/discrete/numeric/modulo.lisp
+++ b/src/discrete/numeric/modulo.lisp
@@ -1,0 +1,151 @@
+;;;; src/discrete/numeric/modulo.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+;;; Typed modulo arithmetic where every Modulo type has a unique group order.
+
+;;; Usage: (coalton (fn (x) (the-moduo 4 (modulo x))))
+;;;        (coalton ((the-modulo 10) (* 11 -4)))
+
+;; Defines `the-modulo'
+(has-singleton Modulo)
+
+(coalton-toplevel
+
+  (repr :transparent)
+  (define-type (Modulo :a)
+    "Modular arithmetic type."
+    ;; For (%Modulo A), A must be less than (extract-single (%Modulo A))
+    (%Modulo UFix))
+
+  (declare %from-modulo ((Modulo :a) -> UFix))
+  (define (%from-modulo a)
+    (match a
+      ((%Modulo a) a)))
+
+  (declare %to-modulo (Nat :a => :a -> Integer -> (Modulo :a)))
+  (define (%to-modulo nat a)
+    (let b = (mod (fromInt a) (fromNat nat)))
+    (%Modulo (lisp UFix (b) b)))
+
+  (declare modulo ((Nat :n) (Integral :a) => :a -> (Modulo :n)))
+  (define (modulo n)
+    "Converts a number into a modular arithmetic number."
+    (%to-modulo single (toInteger n)))
+
+  (declare modulo-enforce (Nat :a => Modulo :a -> Modulo :a))
+  (define modulo-enforce (compose modulo %from-modulo))
+
+  (declare modulo->ufix ((Nat :a) => (Modulo :a) -> UFix))
+  (define modulo->ufix %from-modulo)
+
+  (declare modulo->integer ((Nat :a) => (Modulo :a) -> Integer))
+  (define (modulo->integer a)
+    (toInteger (modulo->ufix a)))
+
+  (define-instance (Nat :a => (Into (Modulo :a) Integer))
+    (define into modulo->integer))
+
+  (declare convert-modulo ((Nat :a) (Nat :b) => (Modulo :a) -> (Modulo :b)))
+  (define (convert-modulo a)
+    "Conversion from 'A mod n' to some 'A mod m'."
+    (modulo (modulo->ufix a)))
+
+  (define-instance (Nat :a => Eq (Modulo :a))
+    (define (== a b)
+      (== (%from-modulo a) (%from-modulo b))))
+
+  (define-instance (Nat :a => Hash (Modulo :a))
+    (define (hash n)
+      (modulo->ufix n)))
+
+  (define-instance (Nat :a => Ord (Modulo :a))
+    (define (<=> a b)
+      (<=> (%from-modulo a) (%from-modulo b))))
+
+  (declare %modulo-64-times
+           (Nat :a => :a -> UFix -> Modulo :a -> Modulo :a -> Modulo :a))
+  (define (%modulo-64-times _ n a-mod b-mod)
+    "With A-MOD and B-MOD less than or equal to N<64, compute (mod (* A B) N)"
+    ;; We are gaurenteed U16 as the elements are less than 64^2
+    (let to-u16 = (fn (x) (lisp U16 (x) x)))
+    (let m = (to-u16 n))
+    (let a = (to-u16 (modulo->ufix a-mod)))
+    (let b = (to-u16 (modulo->ufix b-mod)))
+    ;; We need a 64-bit float for N<64 modular multiplication
+    (let x = (the Double-Float (into a)))
+    (let y = (* x (into b)))
+    (let c = (lisp U16 (y m)
+               (cl:nth-value 0 (cl:floor y m))))
+    (let ab = (* a b))
+    (let cm = (* c m))
+    ;; ab - cm mod m
+    (if (>= ab cm)
+        (modulo (- ab cm))
+        (modulo (- (- m ab) cm))))
+
+  (declare %modulo-times (Nat :a => :a -> Modulo :a -> Modulo :a -> Modulo :a))
+  (define (%modulo-times _ a b)
+    "Equals (mod (* A B) n) where n = (fromNat (extract-single a))."
+    (modulo (* (modulo->ufix a) (modulo->ufix b))))
+
+  (declare %modulo-minus
+           (Nat :a => :a -> UFix -> (Modulo :a) -> (Modulo :a) -> (Modulo :a)))
+  (define (%modulo-minus _ m a-mod b-mod)
+    "Equals (mod (- A-MOD B-MOD) n) where n = (fromNat (extract-single A-MOD))."
+    (let a = (%from-modulo a-mod))
+    (let b = (%from-modulo b-mod))
+    (%Modulo
+     (if (>= a b)
+         (- a b)
+         (+ a (- m b)))))
+
+  (declare %modulo-plus (Nat :a => :a
+                             -> UFix -> Modulo :a ->  Modulo :a -> Modulo :a))
+  (define (%modulo-plus _ m a-mod b-mod)
+    "Equals (mod (+ A-MOD B-MOD) n) where n = (fromNat (extract-single A-MOD))."
+    (let a = (%from-modulo a-mod))
+    (let b = (%from-modulo b-mod))
+    (let m-b = (- m b))
+    (%Modulo
+     (if (>= a m-b)
+           (- a m-b)
+           (+ a b))))
+
+  (define-instance (Nat :a => (Num (Modulo :a)))
+    (define +
+      (progn
+        (let nat = single)
+        (let n = (fromNat nat))
+        (%modulo-plus nat n)))
+    (define -
+      (progn
+        (let nat = single)
+        (let n = (fromNat nat))
+        (%modulo-minus nat n)))
+    (define *
+      (progn
+       (let nat = single)
+       (let n = (fromNat nat))
+       (cond
+         ((< n 64) (%modulo-64-times nat n))
+         (True (%modulo-times nat)))))
+    (define fromInt modulo))
+
+  (define-instance (Nat :a => (Remainder (Modulo :a)))
+    (define (quot a b)
+      (%Modulo (quot (%from-modulo a) (%from-modulo b))))
+    (define (rem a b)
+      (%Modulo (rem (%from-modulo a) (%from-modulo b))))
+    (define (quotRem a b)
+      (match (quotRem (%from-modulo a) (%from-modulo b))
+        ((Tuple a b) (Tuple (%Modulo a) (%Modulo b)))))
+    (define (div a b)
+      (%Modulo (div (%from-modulo a) (%from-modulo b))))
+    (define (mod a b)
+      (%Modulo (mod (%from-modulo a) (%from-modulo b))))
+    (define (divMod a b)
+      (match (divMod (%from-modulo a) (%from-modulo b))
+        ((Tuple a b) (Tuple (%Modulo a) (%Modulo b)))))))

--- a/src/discrete/numeric/naturals.lisp
+++ b/src/discrete/numeric/naturals.lisp
@@ -1,0 +1,75 @@
+;;;; src/discrete/numeric/naturals.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+;;; Type-level programming using Peano natural numbers
+
+;;; Usage (coalton (fromNat (the #.(nat-type 2) single)))
+
+(coalton-toplevel
+  (define-class (Singleton :a)
+    "Type with a single value associated with it."
+    (single :a))
+
+  (define-class (Singleton :a => Nat :a)
+    "Type level natural number singleton"
+    (fromNat (:a -> UFix)))
+
+  (define-instance (Singleton Unit)
+    (define single Unit))
+
+  (repr :enum)
+  (define-type Z Z)
+  (define-instance (Singleton Z)
+    (define single Z))
+
+  (define-instance (Nat Z)
+    (define (fromNat _) 0))
+
+  (repr :transparent)
+  (define-type (S :a)
+    (S :a))
+
+  (define-instance (Singleton :a => (Singleton (S :a)))
+    (define single
+      (S single)))
+
+  (define-instance (Nat :a => (Nat (S :a)))
+    (define fromNat
+      (progn
+        (let nat = single)
+        ;; Pre-calculate the return value.
+        (let natural = (+ 1 (match nat ((S m) (fromNat m)))))
+        ((the (:a -> :a -> UFix)
+              (fn (_ _) natural)) nat))))
+
+  (declare extract-single (Singleton :a => (:c :a) -> :a))
+  (define (extract-single _)
+    "Extracts the singleton from the right-most type."
+    single)
+
+  (declare with-singleton (Singleton :a => :a -> (:c :a) -> (:c :a)))
+  (define (with-singleton _ p)
+    "Carries over the singleton across constructors."
+    p))
+
+(cl:defun nat-type (n)
+  (cl:if (cl:eql n 0)
+         'Z
+         `(S ,(nat-type (cl:- n 1)))))
+
+(cl:defmacro has-singleton (type cl:&rest vars)
+  (cl:let ((def (cl:intern (cl:concatenate
+                            'cl:string "THE-" (cl:symbol-name type)))))
+    `(cl:defmacro ,def (n cl:&optional m)
+       (cl:if m
+              `(the (,(cl:intern ,(cl:symbol-name type)) ,,@vars ,(nat-type n)) ,m)
+              `(fn (x) (the (,(cl:intern ,(cl:symbol-name type))
+                             ,,@vars
+                             ,(nat-type n)) x))))))
+
+;; (coalton (make-nat 2))
+(cl:defmacro make-nat (n)
+  `(the ,(nat-type n) ,(nat-type n)))

--- a/src/discrete/numeric/root2plex.lisp
+++ b/src/discrete/numeric/root2plex.lisp
@@ -1,0 +1,237 @@
+;;;; src/discrete/numeric/root2plex.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+;;; Defines functions on the type representing the form a + b √2
+
+(coalton-toplevel
+
+  (define-type (Root2plex :a)
+    "A ring R adjoin the square root of two:
+     R[√2] = {a + b √2 | a,b ∈ R}
+
+     When R is the Reals, R[√2] is isomorphic to perplex numbers.
+     When √2∈R, R≃R[√2]"
+    (Root2plex :a :a))
+
+  (declare root2-real-part ((Num :a) => ((Root2plex :a) -> :a)))
+  (define (root2-real-part z)
+    "Represents a in the expression a + b √2."
+    (match z
+      ((Root2plex a _) a)))
+
+  (declare root2-root-part ((Num :a) => ((Root2plex :a) -> :a)))
+  (define (root2-root-part z)
+    "Represents b in the expression a + b √2."
+    (match z
+      ((Root2plex _ b) b)))
+
+  (define-instance (Functor Root2plex)
+    (define (map f x)
+      (match x
+        ((Root2plex a b) (Root2plex (f a) (f b))))))
+
+  (define-instance ((Num :a) => (Eq (Root2plex :a)))
+    (define (== p q)
+      (and (== (root2-real-part p) (root2-real-part q))
+           (== (root2-root-part p) (root2-root-part q)))))
+
+  (define-instance ((Num :a) => (Num (Root2plex :a)))
+    (define (+ x y)
+      (Root2plex (+ (root2-real-part x) (root2-real-part y))
+                 (+ (root2-root-part x) (root2-root-part y))))
+    (define (- x y)
+      (Root2plex (- (root2-real-part x) (root2-real-part y))
+                 (- (root2-root-part x) (root2-root-part y))))
+    (define (* x y)
+      (match (Tuple x y)
+        ((Tuple (Root2plex a b)
+                (Root2plex c d))
+         (Root2plex (+ (* a c) (* 2 (* b d)))
+                    (+ (* a d) (* b c))))))
+    (define (fromInt x)
+      (Root2plex (fromInt x) 0)))
+
+  (define-instance (Complex :a => (Complex (Root2plex :a)))
+    (define (complex a b)
+      (makeComplex a b))
+    (define (real-part a)
+      (complexReal a))
+    (define (imag-part a)
+      (complexImag a)))
+
+  (define-instance (Into (Complex (Root2plex Integer))
+                         (Complex (Root2plex Fraction)))
+    (define (into x)
+      (complex
+       (Root2plex
+        (exact/ (root2-real-part (real-part x)) 1)
+        (exact/ (root2-root-part (real-part x)) 1))
+       (Root2plex
+        (exact/ (root2-real-part (imag-part x)) 1)
+        (exact/ (root2-root-part (imag-part x)) 1)))))
+
+  (define-instance (Rational :a => (Quantizable (Root2plex :a)))
+    (define (floor x)
+      (let (Root2plex a b) = x)
+      (let a-floor = (floor a))
+      (let b-floor = (* (sign b) (isqrt (floor (* 2 (^ b 2))))))
+      (let n = (+ a-floor b-floor))
+      (let m = (same-type x (fromint n)))
+      (cond
+        ((<= (+ m 1) x) (+ n 1))
+        ((<= m x) n)
+        (true (- n 1))))
+    (define (proper x)
+      (let trunc = (* (sign x) (floor (abs x))))
+      (let rem = (- x (fromInt trunc)))
+      (Tuple trunc rem))
+    (define (ceiling x)
+      (negate (floor (negate x)))))
+
+  (define-instance ((Num :a) => (Linear (Root2plex :a) :a))
+    (define (.* s v)
+      (match v
+        ((Root2plex a b)
+         (Root2plex (* s a) (* s b))))))
+
+  ;; R[√2] is NOT an inner product space
+  (define-instance ((Num :a) => (Inner (Root2plex :a) :a))
+    (define (<.> x y)
+      (match (Tuple x y)
+        ((Tuple (Root2plex xa xb)
+                (Root2plex ya yb))
+         (- (* xa ya) (* 2 (* xb yb)))))))
+
+  (define-class ((Num :a) => (ExactRoot2 :a))
+    "Any numeric type constructed with an exact non-zero representation of √2
+must implement the involution ±√2 ↦ ∓√2, otherwise the identity will suffice."
+    (root2-conjugate (:a -> :a)))
+
+  (define-instance ((Num :a) => (ExactRoot2 (Root2plex :a)))
+    (define (root2-conjugate z)
+      "Maps a + b √2 to a - b √2"
+      (Root2plex (root2-real-part z) (negate (root2-root-part z)))))
+
+  (define-instance ((Complex :a) => (ExactRoot2 (Complex (Root2plex :a))))
+    (define (root2-conjugate z)
+      (complex (root2-conjugate (real-part z))
+               (root2-conjugate (imag-part z)))))
+
+  (declare root2-reciprocal ((Num :a) (Dividable :a :b)
+                             => ((Root2plex :a) -> (Root2plex :b))))
+  (define (root2-reciprocal x)
+    "The multiplicative invserse of an X ∈ R[√2]. Note that 1/(a + b √2) is
+undefined for a = -b√2."
+    ;; 1/X = σ(X)/(X σ(X)) = σ(X)/ǁXǁ²
+    ;; 1/(a + b √2) = (a - √2b)/(a² - 2b²)
+    (map (fn (y) (general/ y (square-norm x)))
+         (root2-conjugate x)))
+
+  (define-instance (Dividable (Root2plex Integer) (Root2plex Fraction))
+    (define (general/ a b) (* (map fromInt a) (root2-reciprocal b))))
+
+  ;; This is only a field for rationals
+  (define-instance  ((Reciprocable :a) => (Reciprocable (Root2plex :a)))
+    (define (/ a b)
+      (* (map (fn (y) (general/ y 1)) a)
+         (root2-reciprocal b)))
+    (define (reciprocal x) (root2-reciprocal x)))
+
+  (declare root2 ((Num :a) => (Root2plex :a)))
+  (define root2
+    "The root 2 unit √2 in the form 0 + 1 √2."
+    (Root2plex 0 1))
+
+  (declare root2->floating ((Into :a :b) (Num :a) (Elementary :b) =>
+                            ((Root2plex :a) -> :b)))
+  (define (root2->floating x)
+    (+ (into (root2-real-part x))
+       (* (into (root2-root-part x)) (sqrt 2))))
+
+  (declare zroot2->floating ((Elementary :b) =>
+                             ((Root2plex Integer) -> :b)))
+  (define (zroot2->floating x)
+    (+ (fromInt (root2-real-part x))
+       (* (fromInt (root2-root-part x)) (sqrt 2))))
+
+  (declare rroot2->floating ((Elementary :b) =>
+                             ((Root2plex Fraction) -> :b)))
+  (define (rroot2->floating x)
+    (+ (/ (fromInt (numerator (root2-real-part x)))
+          (fromInt (denominator (root2-real-part x))))
+       (* (/ (fromInt (numerator (root2-root-part x)))
+             (fromInt (denominator (root2-root-part x))))
+          (sqrt 2))))
+
+  (define-instance ((Num :a) (Into :a Single-Float) =>
+                    (Into (Root2plex :a) Single-Float))
+    (define into root2->floating))
+
+  (define-instance ((Num :a) (Into :a Double-Float) =>
+                    (Into (Root2plex :a) Double-Float))
+    (define into root2->floating))
+
+  (define-instance ((Num :b) (Into :a :b) => (Into :a (Root2plex :b)))
+    (define (into x) (Root2plex (into x) 0)))
+
+  (define-instance (Dagger :a => (Dagger (Root2plex :a)))
+    (define (dagger x)
+      (match x
+        ((Root2plex a b) (Root2plex (dagger a) (dagger b))))))
+
+  (declare signed-square ((Num :a) (Ord :a) => :a -> :a))
+  (define (signed-square a) (* a (abs a)))
+
+  (define-instance ((Num :a) (Ord :a) => (Ord (Root2plex :a)))
+    (define (<=> x y)
+      (match (Tuple x y)
+        ((Tuple (Root2plex xa xb)
+                (Root2plex ya yb))
+         ;; xa + xb√2 <=> ya + yb√2
+         ;; sign(xa - ya)(xa - ya)² <=> 2 sign(yb - xb)(yb - xb)²
+         (<=> (signed-square (- xa ya))
+              (* 2 (signed-square (- yb xb))))))))
+
+  (declare root2-normed-fraction ((Inner (Root2plex :a) :a) (Num :a)
+                                  => (:a -> :a -> :a)
+                                  -> (Root2plex :a) -> (Root2plex :a)
+                                  -> (Root2plex :a)))
+  (define (root2-normed-fraction f a b)
+    (let dividend = (* a (root2-conjugate b)))
+    (let a1 = (root2-real-part dividend))
+    (let a2 = (root2-root-part dividend))
+    (let divisor = ((the ((Root2plex :a) -> :a) square-norm) b))
+    ;; (a1+a2√2)/(b1+b2√2)=(a1+a2√2)(b1-√2b2)/(b1²-2b2²)
+    (Root2plex (f a1 divisor)
+               (f a2 divisor)))
+
+  (define-instance ((Remainder :a)
+                    => (Remainder (Root2plex :a)))
+    (define (quot a b)
+      (root2-normed-fraction quot a b))
+    (define (rem a b)
+      (- a (* b (quot a b))))
+    (define (quotRem a b)
+      (let result-quot = (quot a b))
+      (let result-rem = (- a (* b result-quot)))
+      (Tuple result-quot result-rem))
+    (define (mod a b)
+      (root2-normed-fraction mod a b))
+    (define (div a b)
+      (- a (* b (mod a b))))
+    (define (divMod a b)
+      (let result-div = (div a b))
+      (let result-mod = (- a (* b result-div)))
+      (Tuple result-div result-mod)))
+
+  (define-instance ((Factorable :a) (Ord :a)
+                    => (Factorable (Root2plex :a)))
+    (define (euclid-div a b)
+      (root2-normed-fraction euclid-div a b))
+    (define (canonical-factor a) (abs a))
+    (define (euclid-norm a) (euclid-norm ((the ((Root2plex :a) -> :a)
+                                               square-norm) a)))
+    (define (euclid-gcd a b) (canonical-gcd a b))))

--- a/src/discrete/numeric/utilities.lisp
+++ b/src/discrete/numeric/utilities.lisp
@@ -1,0 +1,216 @@
+;;;; src/discrete/numeric/utilities.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/numeric)
+
+(coalton-toplevel
+
+  (define (blum-blum-shub p q s)
+    "Given two primes P and Q, as well as a seed S, create psuedu-random number
+generator that takes an N and returns a value between 0 and 1"
+    (let m = (* p q))
+    (let lambda-m = (lcm (- p 1) (- q 1)))
+    ;; Functional version
+    (fn (n)
+      (exact/ (expt-mod s (expt-mod 2 n lambda-m) m) m)))
+
+  (define psuedo-random
+    "Given a N return a psuedo-random number between 0 and 1."
+    (blum-blum-shub 11 23 3))
+
+  (define-class (Monoid :a => Group :a)
+    "Type with a group-like structure (i.e. an invertable Monoid)"
+    (invert (:a -> :a)))
+
+  (define-class (ConstructComplex :a)
+    (makeComplex (:a -> :a -> (Complex :a)))
+    (complexReal (Complex :a -> :a))
+    (complexImag (Complex :a -> :a)))
+
+  (define-instance (Num :a => (ConstructComplex :a))
+    (define (makeComplex a b)
+      (coalton-library/math/complex::%Complex a b))
+    (define (complexReal a)
+      (match a
+        ((coalton-library/math/complex::%Complex a _) a)))
+    (define (complexImag a)
+      (match a
+        ((coalton-library/math/complex::%Complex _ b) b))))
+
+  (declare same-type (:a -> :a -> :a))
+  (define (same-type _ x) x)
+
+  (declare fraction->reciprocable (Reciprocable :a => Fraction -> :a))
+  (define (fraction->reciprocable x)
+      (/ (fromInt (numerator x)) (fromInt (denominator x))))
+
+  (declare expt-mod (Integer -> Integer -> Integer -> Integer))
+  (define (expt-mod a x n)
+    "Defines a less naïve (mod (expt A X) N) for non-negative X N."
+    (when (< x 0)
+      (error "Negative power in `expt-mod'."))
+    (when (< n 0)
+      (error "Negative base in `expt-mod'."))
+    (let ((expt-mod-rec
+            (fn (base power result)
+              (if (> power 0)
+                  (expt-mod-rec (mod (* base base) n)
+                                (ash power -1)
+                                (if (odd? power)
+                                    (mod (* result base) n)
+                                    result))
+                  result))))
+      (expt-mod-rec (mod a n) x (mod 1 n))))
+
+  (declare exact-ilog (Integer -> Integer -> (Optional Integer)))
+  (define (exact-ilog b x)
+    "Computes the logarithm with base B of X only if the result is an integer."
+    (if (== 0 (mod b x))
+        (Some (ilog b x))
+        None))
+
+  (declare fractional-factor ((Functor :a) (Num (:a Fraction))
+                              => (:a Fraction) -> Integer))
+  (define (fractional-factor a)
+    "Given an A with Fraction coefficients, for fractions with prime-factorable
+numerators return the least common denominator of all said fractions; or for
+fractions with denominators of 1, return the negative least common numerator."
+    (let factor = (cell:new 0))
+    (let set-factor! =
+      (fn (x)
+        (let f = (cell:read factor))
+        (let top = (numerator x))
+        (let bottom = (denominator x))
+        (cond
+          ((and (<= f 0) (== bottom 1))
+           (cell:write! factor (negate (gcd top f))))
+          ((== f 0)
+           (cell:write! factor bottom))
+          ((/= f bottom)
+           (cell:write! factor (lcm f bottom))))
+        Unit))
+    (map set-factor! a)
+    (cell:read factor))
+
+  (declare integer-fractional? ((Functor :a) => (:a Fraction) -> Boolean))
+  (define (integer-fractional? x)
+    "Checks if fractional coefficients can all be represented with integers."
+    (let ret = (cell:new True))
+    (let integer-fraction!? =
+      (fn (y)
+        (if (== 1 (denominator y))
+            True
+            (return (cell:write! ret False)))))
+    (map integer-fraction!? x)
+    (cell:read ret))
+
+  (declare smallest-dividing-exponent
+           ((Functor :a) (Num (:a Integer)) (Reciprocable (:a Fraction)) =>
+            (:a Fraction) -> (:a Integer) -> (Optional Integer)))
+  (define (smallest-dividing-exponent a b)
+    "Find the smallest integer x such that AB^x has integer coefficients (SDE)."
+    (let b-frac = (map (fn (x) (exact/ x 1)) b))
+    (when (or (== b-frac a) (== b-frac (negate a))) (return (Some 1)))
+    (when (or (== a 1) (== a 0)) (return (Some 0)))
+    (when (or (== b-frac 1) (== b-frac 0)) (return None))
+    (let k = (* 2 (fractional-factor a)))
+    (let ab^i = (cell:new a))
+    (let ((compute-exponent
+            (fn (i)
+              (cond
+                ((< k i) None)
+                ((integer-fractional?
+                  (cell:write! ab^i
+                               (* (cell:read ab^i) (^^ b-frac (sign i)))))
+                 (Some i))
+                (True (compute-exponent (+ i (sign k))))))))
+      (compute-exponent (sign k))))
+
+  (define-class (Num :a => (Factorable :a))
+    "A Euclidean domain such that with a Euclidean function n
+    a = (+ (* b (euclid-div a b) (euclid-mod a b))
+    where (== (euclid-mod a b) fromInteger 0) (< (n (euclid-mod a b)) (n b))
+
+    For example, `abs' is a Euclidean function for integer, and `extension-norm'
+    is one for Guassian integers.
+
+    The `euclid-gcd' is an algorithm equivalent per type to Euclid's Algorithm
+defined by repeated calls of `euclid-mod' which on Reals is a rounded modulo
+defined by `euclid-div' which again on reals is centered/rounded division.
+Euclid's Algorithm can admit multiple factors unique up to multiplication of
+units, `canonical-factor' refines this choice - typically with the predicate:
+toInteger (canonical-factor x) = max({toInteger(x*u) | u is a unit})."
+    ;; Multiplication of units s.t.
+    ;; toInteger (canonical-factor x) = max({toInteger(x*u) | u is a unit})
+    (canonical-factor (:a -> :a))
+    (euclid-norm (:a -> Integer))
+    ;; Centered division for Ord (e.g. round/)
+    (euclid-div (:a -> :a -> :a))
+    ;; Euclid's Algorithm using `euclid-mod' or equivantly more efficient.
+    (euclid-gcd (:a -> :a -> :a)))
+
+  (declare euclid-field-norm ((Num :a) => :a -> Integer))
+  (define (euclid-field-norm x)
+    (if (== x 0) 0 1))
+
+  (declare euclid-mod ((Factorable :a) => :a -> :a -> :a))
+  (define (euclid-mod a b)
+    (- a (* b (euclid-div a b))))
+
+  (declare general-gcd ((Factorable :a) => :a -> :a -> :a))
+  (define (general-gcd a b)
+    "The \"greatest\" common denominator up to a unit (e.g. for integers this
+means it may be negative)."
+    (if (== b 0) a
+        (general-gcd b
+                     (euclid-mod a b))))
+
+  (declare canonical-gcd ((Factorable :a) => :a -> :a -> :a))
+  (define (canonical-gcd a b)
+    "The \"greatest\" common denominator up to a unit with `canonical-factor'
+deciding a factor equivalent by multiplication of units from `general-gcd'.
+For example if `canonical-factor' is `abs' (*±1) then this is the standard GCD."
+    (canonical-factor (general-gcd a b)))  
+
+  (define-instance (Factorable Integer)
+    (define canonical-factor abs)
+    (define euclid-norm abs)
+    (define (euclid-div a n)
+      (round/ a n))
+    (define (euclid-gcd a n)
+      (gcd a n)))
+
+  (define-instance (Factorable Fraction)
+    (define canonical-factor abs)
+    (define euclid-norm (compose floor abs))
+    (define (euclid-div a b)
+      (fromInt
+       (euclid-div
+        (* (numerator a) (denominator b))
+        (* (numerator b) (denominator a)))))
+    (define euclid-gcd canonical-gcd))
+
+  (define-instance (Factorable (Complex Integer))
+    (define (canonical-factor x)
+      (let a = (real-part x))
+      (let b = (imag-part x))
+      (cond
+        ((> 0 a)
+         (negate x))
+        ((and (> b 0) (< a b))
+         (complex b (negate a)))
+        ((and (< b 0) (> a b))
+         (complex (negate b) a))
+        (True x)))
+    (define (euclid-norm a)
+      (+ (* (real-part a) (real-part a))
+         (* (imag-part a) (imag-part a))))
+    (define (euclid-div x y)
+      (let dividend = (* x (conjugate y)))
+      (let a = (real-part dividend))
+      (let b = (imag-part dividend))
+      (let divisor = (euclid-norm y))
+      (complex (euclid-div a divisor)
+               (euclid-div b divisor)))
+    (define (euclid-gcd x y) (general-gcd x y))))

--- a/src/discrete/operators/c2root2.lisp
+++ b/src/discrete/operators/c2root2.lisp
@@ -1,0 +1,54 @@
+;;;; src/discrete/operators/c2root2.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Instead of repeatedly multiplying/dividing by √2, define the asscoiated
+;;; linear transformation, "compose" it repeadedly, and then apply it.
+
+(coalton-toplevel
+  (define-type (C2Root2 :a)
+    "Multiplication of a Cyclotomic8 by Root2"
+    (Times1 :a)
+    (TimesRoot2 :a))
+
+  (declare divide-root2 (OneHalf :a => C2Root2 :a))
+  (define divide-root2 (TimesRoot2 oneHalf))
+
+  ;; Up to the dyadic coefficient, this is a Cyclic group of order 4
+  (define-instance (Num :a => (Composable (C2Root2 :a)
+                                          (C2Root2 :a) (C2Root2 :a)))
+    (define (apply a b)
+      (match (Tuple a b)
+        ;; Times1
+        ((Tuple (Times1 x) (Times1 y)) (Times1 (* x y)))
+
+        ((Tuple (Times1 x) (TimesRoot2 y)) (TimesRoot2 (* x y)))
+        ((Tuple (TimesRoot2 x) (Times1 y)) (TimesRoot2 (* x y)))
+
+        ((Tuple (TimesRoot2 x) (TimesRoot2 y)) (Times1 (* 2 (* x y)))))))
+
+  ;; This can be represented by 4x4 matrices:
+  ;; matrix([0,1,0,-1],[1,0,1,0],[0,1,0,1],[-1,0,1,0])
+  (define-instance (Num :a => (Composable (C2Root2 :a)
+                                          (Cyclotomic8 :a) (Cyclotomic8 :a)))
+    (define (apply x y)
+      (match y
+        ((Cyclotomic8 a b c d)
+         (match x
+           ((Times1 coeff)
+            (Cyclotomic8 (* coeff a) (* coeff b) (* coeff c) (* coeff d)))
+           ((TimesRoot2 coeff)
+            (Cyclotomic8 (* coeff (- b d)) (* coeff (+ c a))
+                         (* coeff (+ b d)) (* coeff (- c a)))))))))
+
+  (define-instance ((Num :a) => (Identity (C2Root2 :a)))
+    (define identity (Times1 1)))
+  (declare times-root2^^ ((OneHalf :a)
+                    => Integer -> (Cyclotomic8 :a) -> (Cyclotomic8 :a)))
+  (define (times-root2^^ n omega)
+    "Takes an OMEGA and multiplies it by √2^n"
+    (if (> n 0)
+        (constructor-act (@^ (TimesRoot2 1) n) omega)
+        (constructor-act (@^ divide-root2 (negate n)) omega))))

--- a/src/discrete/operators/clifford.lisp
+++ b/src/discrete/operators/clifford.lisp
@@ -1,0 +1,83 @@
+;;;; src/discrete/operators/clifford.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Wrapper around Quilc's Clifford groups
+
+(has-singleton Clifford)
+
+(cl:defmacro clifford-element (cl:&body body)
+  (cl:let ((c (cl:eval `(cl-quil.clifford:clifford-element ,@body))))
+    `(the-clifford
+      ,(cl-quil.clifford::num-qubits c)
+      (lisp (Clifford :a) () (cl-quil.clifford:clifford-element ,@body)))))
+
+(coalton-toplevel
+  (repr :native cl-quil.clifford:clifford)
+  (define-type (Clifford :nat))
+
+  (define (count-clifford n)
+    (lisp Integer (n)
+      (cl-quil.clifford:count-clifford n)))
+
+  (declare pauli->clifford (Nat :a => (Pauli :a) -> (Clifford :a)))
+  (define (pauli->clifford p)
+    (lisp (Clifford :a) (p)
+      (cl-quil.clifford:clifford-from-pauli p)))
+
+  (declare random-clifford (Nat :a => Unit -> (Clifford :a)))
+  (define (random-clifford)
+    (let nat = single)
+    (let n = (fromNat nat))
+    (with-singleton nat
+      (lisp (Clifford :a) (n)
+        (cl-quil.clifford::random-clifford n))))
+
+  (define-instance (Eq (Clifford :n))
+    (define (== a b)
+      (lisp Boolean (a b)
+        (cl-quil.clifford:clifford= a b))))
+
+  (define-instance (Hash (Clifford :n))
+    (define (hash c)
+      (lisp UFix (c)
+        (cl-quil.clifford::clifford-hash c))))
+
+  (define-instance (Composable (Clifford :n) (Clifford :n) (Clifford :n))
+    (define (apply a b)
+      (lisp (Clifford :a) (a b)
+        (specify-generic-function #'cl-quil.clifford:group-mul
+                                  (cl:list a b)
+                                  'cl-quil.clifford:clifford))))
+
+  (define-instance (Composable (Clifford :n) (Pauli :n) (Pauli :n))
+    (define (apply c p)
+      (lisp (Pauli :a) (c p)
+        'cl-quil.clifford:apply-clifford c p)))
+
+  (define-instance (Nat :a => Identity (Clifford :a))
+    (define identity
+      (progn
+        (let nat = single)
+        (let n = (fromNat nat))
+        (with-singleton nat
+          (lisp (Clifford :a) (n)
+            (cl-quil.clifford:clifford-identity n))))))
+
+  (define-instance (Nat :a => Inverse (Clifford :a))
+    (define (inverse p)
+      (lisp (Clifford :a) (p)
+        (specify-generic-function #'cl-quil.clifford:group-inv
+                                  (cl:list p)
+                                  'cl-quil.clifford:clifford)))
+    (define (safe-inverse p)
+      (Some
+       (lisp (Clifford :a) (p)
+         (specify-generic-function #'cl-quil.clifford:group-inv
+                                   (cl:list p)
+                                   'cl-quil.clifford:clifford)))))
+
+  (define (clifford-phase-identity p)
+    (pauli->clifford (pauli-phase-identity p))))

--- a/src/discrete/operators/gates1.lisp
+++ b/src/discrete/operators/gates1.lisp
@@ -1,0 +1,356 @@
+;;;; src/discrete/operators/gates1.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+(coalton-toplevel
+
+  ;; Used for expanding MAForms
+  (define-type Universal1
+    "One qubit gates that make up Clifford+T
+where X, Y, Z, H, S, T, E = HS³ω³, and W = ωI = exp(iπ/4)I"
+    XGate YGate ZGate SGate HGate TGate EGate WGate)
+
+  (define-instance (Eq Universal1)
+    (define (== a b)
+      (lisp Boolean (a b)
+        (cl:eq a b))))
+
+  (define-instance (Into HadamardT (List Universal1))
+    (define (into ht)
+      (match ht
+        ((HT-H) (make-list HGate))
+        ((HT-T^^ n)
+         (match (mod n 8)
+           (0 Nil)
+           (1 (make-list TGate))
+           (2 (make-list SGate))
+           (3 (make-list TGate SGate))
+           (4 (make-list ZGate))
+           (5 (make-list TGate ZGate))
+           (6 (make-list SGate ZGate))
+           (7 (make-list TGate SGate ZGate)))))))
+
+  (repr :enum)
+  (define-type OutputGate1
+    "Phase invariant universal gateset for 1 qubit."
+    Discrete-S Discrete-H Discrete-T)
+
+  (declare universal1->outputgate1 ((List Universal1) -> (List OutputGate1)))
+  (define (universal1->outputgate1 gates)
+    "Converts a list of Uniersal1 GATES to a list of Output1Gate. To get
+simplification see (List Universal1) to MAForm to (List OutputGate1)."
+    (match gates
+      ((Cons gate gates)
+       (list:append
+        (match gate
+          ((TGate) (make-list Discrete-T))
+          ((HGate) (make-list Discrete-H))
+          ((SGate) (make-list Discrete-S))
+          ((ZGate) (make-list Discrete-S Discrete-S))
+          ((XGate) (make-list Discrete-H Discrete-S Discrete-S Discrete-H))
+          ((YGate) (<> (<> (make-list Discrete-H Discrete-S)
+                           (universal1->outputgate1 (make-list ZGate XGate)))
+                       (make-list Discrete-S Discrete-H)))
+          ((EGate) (Cons Discrete-H (list:repeat 3 Discrete-S)))
+          ((WGate) nil))
+        (universal1->outputgate1 gates)))
+      ((Nil) Nil)))
+
+  (define-instance (Into OutputGate1 Universal1)
+    (define (into g)
+      (match g
+        ((Discrete-S) SGate)
+        ((Discrete-H) HGate)
+        ((Discrete-T) TGate))))
+
+  (define-type CliffordGates1
+    "Clifford group for 1 qubit with the phase factor ω = exp(iπ/4)."
+    (CliffordGates1
+     (Modulo #.(nat-type 3))
+     (Modulo #.(nat-type 2))
+     (Modulo #.(nat-type 4))
+     (Modulo #.(nat-type 8))))
+
+  (declare cliffordgates1-get-encoding
+           (CliffordGates1 -> (Tuple4 Integer Integer Integer Integer)))
+  (define (cliffordgates1-get-encoding c)
+    "For a CliffordGates1 element C = E^a X^b S^c ω^d return (Tuple4 a b c d)."
+    (match c
+      ((CliffordGates1 a b c d) (Tuple4 (modulo->integer a)
+                                        (modulo->integer b)
+                                        (modulo->integer c)
+                                        (modulo->integer d)))))
+
+  (define-instance (Eq CliffordGates1)
+    (define (== a b)
+      (== (cliffordgates1-get-encoding a) (cliffordgates1-get-encoding b))))
+
+  (define (cliffordgates1-from-integers a b c d)
+    (CliffordGates1 (fromInt a) (fromInt b) (fromInt c) (fromInt D)))
+
+  (define cliffordgates1-X (CliffordGates1 0 1 0 0))
+  (define cliffordgates1-Y (CliffordGates1 0 1 2 2))
+  (define cliffordgates1-Z (CliffordGates1 0 0 2 0))
+  (define cliffordgates1-H (CliffordGates1 1 0 1 5))
+  (define cliffordgates1-S (CliffordGates1 0 0 1 0))
+  (define cliffordgates1-E (CliffordGates1 1 0 0 0))
+  (define cliffordgates1-W (CliffordGates1 0 0 0 1))
+  (define cliffordgates1-SH (@ cliffordgates1-S cliffordgates1-H))
+
+  (define-type CliffordTCommutator
+    Commute-I Commute-H Commute-SH)
+
+  (define-instance (Into CliffordTCommutator CliffordGates1)
+    (define (into c)
+      (match c
+        ((Commute-I) identity)
+        ((Commute-H) cliffordgates1-H)
+        ((Commute-SH) cliffordgates1-SH))))
+
+  (define-instance (Into CliffordTCommutator (List Universal1))
+    (define (into c)
+      (match c
+        ((Commute-I) Nil)
+        ((Commute-H) (make-list HGate))
+        ((Commute-SH) (make-list SGate HGate)))))
+
+  (declare cliffordgates1-commute-t
+           (CliffordGates1 -> (Tuple CliffordTCommutator CliffordGates1)))
+  (define (cliffordgates1-commute-t c)
+    "For a given C return a (Tuple K C') such that CT = KTC."
+    (match c
+      ((CliffordGates1 a1 b1 c1 d1)
+       (progn
+         (let make-result =
+           (fn (e c2 d2)
+             (Tuple e (CliffordGates1 0 b1 (+ c1 c2) (+ d1 d2)))))
+         (match (Tuple (modulo->integer a1) (modulo->integer b1))
+           ((Tuple 0 0) (make-result Commute-I 0 0))
+           ((Tuple 0 1) (make-result Commute-I 1 7))
+           ((Tuple 1 0) (make-result Commute-H 3 3))
+           ((Tuple 1 1) (make-result Commute-H 2 0))
+           ((Tuple 2 0) (make-result Commute-SH 0 5))
+           ((Tuple 2 1) (make-result Commute-SH 1 4)))))))
+
+  (define-instance (Into CliffordGates1 (List Universal1))
+    (define (into c)
+      (match (cliffordgates1-get-encoding c)
+        ((Tuple4 a b c d)
+         (<> (<> (list:repeat a EGate)
+                 (list:repeat b XGate))
+             (<> (list:repeat c SGate)
+                 (list:repeat d WGate)))))))
+
+  (define-instance (Into CliffordGates1 (List OutputGate1))
+    (define (into c)
+      (match (cliffordgates1-get-encoding c)
+        ((Tuple4 a b c _)
+         (<> (list:concat
+              (list:repeat a
+                ;; E = HSSS (ɷ^3)
+                (make-list Discrete-H Discrete-S Discrete-S Discrete-S)))
+             (<> (list:concat
+                  (list:repeat b
+                    ;; X = HSSH
+                    (make-list Discrete-H Discrete-S Discrete-S Discrete-H)))
+                 (list:repeat c Discrete-S)))))))
+
+  (define-instance (Into Universal1 (Optional CliffordGates1))
+    (define (into ct)
+      (match ct
+        ((XGate) (Some cliffordgates1-X))
+        ((YGate) (Some cliffordgates1-Y))
+        ((ZGate) (Some cliffordgates1-Z))
+        ((SGate) (Some cliffordgates1-S))
+        ((HGate) (Some cliffordgates1-H))
+        ((EGate) (Some cliffordgates1-E))
+        ((WGate) (Some cliffordgates1-W))
+        (_ None))))
+
+  (define-instance (Into Universal1
+                         (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (into ct)
+      (match ct
+        ((XGate) (%Unitary2 (RootUnity8 4) 0 1))
+        ((YGate) (%Unitary2 mempty 0 (Cyclotomic8 0 1 0 0)))
+        ((ZGate) (into (HT-T^^ 4)))
+        ((SGate) (into (HT-T^^ 2)))
+        ((HGate) (into HT-H))
+        ;; E = H S^3 W^3
+        ((EGate) (@ (into HGate) (@ (into (HT-T^^ 6)) (@^ (into WGate) 3))))
+        ((WGate) (%Unitary2 (RootUnity8 2) (Cyclotomic8 0 0 1 0) 0))
+        ((TGate) (into (HT-T^^ 1))))))
+
+  (define-instance (Into CliffordGates1 (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (into c)
+      (match (cliffordgates1-get-encoding c)
+        ((Tuple4 a b c d)
+         (@ (@ (@^ (into EGate) a )
+               (@^ (into XGate) b))
+            (@ (@^ (into SGate) c)
+               (@^ (into WGate) d)))))))
+
+  (define-instance (Into OutputGate1 (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (into c)
+      (into (the Universal1 (into c)))))
+
+  (define-instance (Into CliffordGates1 (Clifford #.(nat-type 1)))
+    (define (into c)
+      (match (cliffordgates1-get-encoding c)
+        ((Tuple4 a b c d)
+         ;;       E^a
+         (@ (@ (@^ (clifford-element X -> Y Z -> X) a)
+               ;; X^b
+               (@^ (pauli->clifford pauli-X) b))
+            ;;    S^c
+            (@ (@^ (clifford-element Z -> Z X -> Y) c)
+               ;; W^d = I
+               (@^ (clifford-element X -> X Z -> Z) d)))))))
+
+  (define-instance (Into (Clifford #.(nat-type 1)) CliffordGates1)
+    (define (into c)
+      (match (hashtable:get %clifford1-table (hash c))
+        ((Some a) a)
+        ((None) (error "Clifford element not found in `%clifford1-table'.")))))
+
+  (define-instance (Composable CliffordGates1 CliffordGates1 CliffordGates1)
+    (define (apply m1 m2)
+      (match (Tuple m1 m2)
+        ((Tuple
+          ;; M1 = E^a1 X^b1 S^c1 W^d1
+          (CliffordGates1 a1 b1 c1 d1)
+          ;; M2 = E^a2 X^b2 S^c2 W^d2
+          (CliffordGates1 a2 b2 c2 d2))
+         ;; M1 M2 = (E^a1 X^b1 S^c1) W^d1 E^a2 (X^b2 S^c2 W^d2)
+         ;; M1 M2 = E^a1 (X^b1 S^c1 E^a2) X^b2 S^c2 W^d2 W^d1
+         (match (cliffordgates1-xse->exsw b1 c1 a2)
+           ;; M3 = E^a3 X^b3 S^c3 W^d3
+           ;; M1 M2 = (E^a1) M3 (X^b2 S^c2) W^d1 W^d2
+           ((CliffordGates1 a3 b3 c3 d3)
+            ;; M1 M2 = (E^a1) E^a3 X^b3 (S^c3 X^b2) S^c2 W^d3 W^d1 W^d2
+            (match (cliffordgates1-sx->sw c3 b2)
+              ;; M1 M2 = (E^a1) E^a3 X^b3 (X^b2 S^c4 W^d4) S^c2 W^d3 W^d1 W^d2
+              ((Tuple c4 d4)
+               (CliffordGates1
+                ;; M1 M2 = (E^a1 E^a3) (X^b3 X^b2) (S^c4 S^c2) (W^d4 W^d3 W^d1 W^d2)
+                (+ a1 a3) (+ b2 b3) (+ c2 c4) (+ (+ d1 d2) (+ d3 d4)))))))))))
+
+  (define-instance (Identity CliffordGates1)
+    (define identity (CliffordGates1 0 0 0 0)))
+
+  (define-instance (Inverse CliffordGates1)
+    (define (inverse m)
+      (match m
+        ((CliffordGates1 a b c d)
+         (match (Tuple3 (modulo->integer a)
+                        (modulo->integer b)
+                        (modulo->integer c))
+           ;;Tuple3 0 0 0) (CliffordGates1 0 0 0 (- 0 d)))
+           ((Tuple3 0 0 1) (CliffordGates1 0 0 3 (- 0 d)))
+           ;;Tuple3 0 0 2) (CliffordGates1 0 0 2 (- 0 d)))
+           ((Tuple3 0 0 3) (CliffordGates1 0 0 1 (- 0 d)))
+           ;;Tuple3 0 1 0) (CliffordGates1 0 1 0 (- 0 d)))
+           ((Tuple3 0 1 1) (CliffordGates1 0 1 1 (- 6 d)))
+           ((Tuple3 0 1 2) (CliffordGates1 0 1 2 (- 4 d)))
+           ((Tuple3 0 1 3) (CliffordGates1 0 1 3 (- 2 d)))
+           ((Tuple3 1 0 0) (CliffordGates1 2 0 0 (- 0 d)))
+           ((Tuple3 1 0 1) (CliffordGates1 1 0 1 (- 2 d)))
+           ((Tuple3 1 0 2) (CliffordGates1 2 1 0 (- 0 d)))
+           ((Tuple3 1 0 3) (CliffordGates1 1 1 3 (- 4 d)))
+           ((Tuple3 1 1 0) (CliffordGates1 2 1 2 (- 2 d)))
+           ((Tuple3 1 1 1) (CliffordGates1 1 1 1 (- 6 d)))
+           ((Tuple3 1 1 2) (CliffordGates1 2 0 2 (- 2 d)))
+           ((Tuple3 1 1 3) (CliffordGates1 1 0 3 (- 4 d)))
+           ((Tuple3 2 0 0) (CliffordGates1 1 0 0 (- 0 d)))
+           ((Tuple3 2 0 1) (CliffordGates1 2 1 3 (- 6 d)))
+           ((Tuple3 2 0 2) (CliffordGates1 1 1 2 (- 2 d)))
+           ((Tuple3 2 0 3) (CliffordGates1 2 0 3 (- 6 d)))
+           ((Tuple3 2 1 0) (CliffordGates1 1 0 2 (- 0 d)))
+           ((Tuple3 2 1 1) (CliffordGates1 2 1 1 (- 6 d)))
+           ((Tuple3 2 1 2) (CliffordGates1 1 1 0 (- 2 d)))
+           ((Tuple3 2 1 3) (CliffordGates1 2 0 1 (- 6 d)))
+           ((Tuple3 a b c)
+            (CliffordGates1 (fromInt a) (fromInt b) (fromInt c) (- 0 d)))))))
+    (define (safe-inverse m)
+      (Some (inverse m))))
+
+  (define %clifford1-table
+    (progn
+      (let table = (hashtable:with-capacity 24))
+      (let increment-cliffordgates1 =
+        (fn (c)
+          "Returns the next non-identity element in the cliffordgates1."
+          (match c
+            ((CliffordGates1 a b c d)
+             (cond
+               ((and (and (== 0 (+ a 1)) (== 0 (+ b 1)))
+                     (and (== 0 (+ c 1)) (== 0 (+ d 1))))
+                None)
+               ((and (== 0 (+ b 1)) (and (== 0 (+ c 1)) (== 0 (+ d 1))))
+                (Some (CliffordGates1 (+ a 1) (+ b 1) (+ c 1) (+ d 1))))
+               ((and (== 0 (+ c 1)) (== 0 (+ d 1)))
+                (Some (CliffordGates1 a (+ b 1) (+ c 1) (+ d 1))))
+               ((== 0 (+ d 1))
+                (Some (CliffordGates1 a b (+ c 1) (+ d 1))))
+               ;; We could actually ignore the d case.
+               (True (Some (CliffordGates1 a b c (+ d 1)))))))))
+      (let ((increment-all
+              (fn (c)
+                (hashtable:set! table
+                                (hash (the-clifford 1 (into c))) c)
+                (match (increment-cliffordgates1 c)
+                  ((Some c-inc) (increment-all c-inc))
+                  ((None) table)))))
+        (increment-all (the CliffordGates1 identity)))))
+
+  (define (cliffordgates1-sx->sw c b)
+    "For a S^C X^B return an equivalent S^C' W^D'"
+    (the-modulo 2 b)
+    (the-modulo 4 c)
+    (match (Tuple (modulo->integer b) (modulo->integer c))
+      ;;Tuple 0 0) (Tuple 0 0))
+      ((Tuple 1 0) (Tuple 0 0))
+      ;;Tuple 0 1) (Tuple 1 0))
+      ;;Tuple 0 2) (Tuple 2 0))
+      ;;Tuple 0 3) (Tuple 3 0))
+      ((Tuple 1 1) (Tuple 3 2))
+      ((Tuple 1 2) (Tuple 2 4))
+      ((Tuple 1 3) (Tuple 1 6))
+      ((Tuple y x)
+       (Tuple (the-modulo 4 (fromInt x)) (the-modulo 8 (fromInt y))))))
+
+  (define (cliffordgates1-xse->exsw b c a)
+    "For a X^B S^C E^A return an equivalent E^A' X^B' S^C' W^D'"
+    (the-modulo 3 a)
+    (the-modulo 2 b)
+    (the-modulo 4 c)
+    (match (Tuple3 (modulo->integer a)
+                   (modulo->integer b)
+                   (modulo->integer c))
+      ;;Tuple3 0 0 0) (CliffordGates1 0 0 0 0))
+      ;;Tuple3 1 0 0) (CliffordGates1 1 0 0 0))
+      ;;Tuple3 2 0 0) (CliffordGates1 2 0 0 0))
+      ;;Tuple3 0 0 1) (CliffordGates1 0 0 1 0))
+      ((Tuple3 1 0 1) (CliffordGates1 2 0 3 6))
+      ((Tuple3 2 0 1) (CliffordGates1 1 1 3 4))
+      ;;Tuple3 0 0 2) (CliffordGates1 0 0 2 0))
+      ((Tuple3 1 0 2) (CliffordGates1 1 1 2 2))
+      ((Tuple3 2 0 2) (CliffordGates1 2 1 0 0))
+      ;;Tuple3 0 0 3) (CliffordGates1 0 0 3 0))
+      ((Tuple3 1 0 3) (CliffordGates1 2 1 3 6))
+      ((Tuple3 2 0 3) (CliffordGates1 1 0 1 2))
+      ;;Tuple3 0 1 0) (CliffordGates1 0 1 0 0))
+      ((Tuple3 1 1 0) (CliffordGates1 1 0 2 0))
+      ((Tuple3 2 1 0) (CliffordGates1 2 1 2 2))
+      ;;Tuple3 0 1 1) (CliffordGates1 0 1 1 0))
+      ((Tuple3 1 1 1) (CliffordGates1 2 1 1 0))
+      ((Tuple3 2 1 1) (CliffordGates1 1 1 1 0))
+      ;;Tuple3 0 1 2) (CliffordGates1 0 1 2 0))
+      ((Tuple3 1 1 2) (CliffordGates1 1 1 0 6))
+      ((Tuple3 2 1 2) (CliffordGates1 2 0 2 6))
+      ;;Tuple3 0 1 3) (CliffordGates1 0 1 3 0))
+      ((Tuple3 1 1 3) (CliffordGates1 2 0 1 4))
+      ((Tuple3 2 1 3) (CliffordGates1 1 0 3 2))
+      ((Tuple3 a b c) (cliffordgates1-from-integers a b c 0)))))

--- a/src/discrete/operators/hadamardt.lisp
+++ b/src/discrete/operators/hadamardt.lisp
@@ -1,0 +1,143 @@
+;;;; src/discrete/operators/hadamardt.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Defines an exact synthsis algorithm and its output type
+
+(coalton-toplevel
+  (define-type HadamardT
+    (HT-H)
+    (HT-T^^ Integer))
+
+  (define-instance (Into HadamardT (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (into x)
+      (match x
+        ((HT-T^^ n) (%Unitary2 (RootUnity8 (fromInt n)) 1 0))
+        ((HT-H) (%Unitary2 (RootUnity8 (fromInt 4))
+                           (Cyclotomic8 (Dyadic -1 1) 0 (Dyadic 1 1) 0)
+                           (Cyclotomic8 (Dyadic -1 1) 0 (Dyadic 1 1) 0))))))
+
+  (define-instance (Into HadamardT (Unitary2 RootUnity8 (Complex (Root2plex Dyadic))))
+    (define (into x)
+      (match x
+        ((HT-T^^ n) (%Unitary2 (RootUnity8 (fromInt n)) 1 0))
+        ((HT-H) (%Unitary2 (RootUnity8 (fromInt 4))
+                           (Complex 0 (Root2plex 0 (Dyadic 1 1)))
+                           (Complex 0 (Root2plex 0 (Dyadic 1 1))))))))
+
+  (define-instance (Into (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)) (List HadamardT))
+    (define into omega-unitary->ht-sequence x))
+
+  (declare omega-unitary->ht-sequence
+           ((Unitary2 RootUnity8 (Cyclotomic8 Dyadic)) -> (List HadamardT)))
+  (define (omega-unitary->ht-sequence x)
+    "Takes an unitary matrix of ℤ[i,√2] and converts it to a list of H/Tⁿ gates.
+(See arXiv:1206.5236)"
+    ;; s = sde(|z_00^2)
+    (let s-first =
+      (smallest-dividing-exponent
+       (map into (cyclotomic8-square-modulus (unitary2-topleft x)))
+       (Root2plex 0 1)))
+    (let find-z-prime =
+      (fn (k u-current)
+        (the (Unitary2 RootUnity8 (Cyclotomic8 Dyadic))
+             (@ (@ (into HT-H) (into (HT-T^^ (negate k))))
+                u-current))))
+    (let ((gen-rec
+            (fn (sequence u-current s k)
+              (let z-prime = (find-z-prime k u-current))
+              (let z-sde = (smallest-dividing-exponent
+                            (map into
+                                 (cyclotomic8-square-modulus (unitary2-topleft z-prime)))
+                            (Root2plex 0 1)))
+              (cond
+                ((<= s 3)
+                 (list:append
+                  sequence
+                  (match (hashtable:get %exact-synth-table (hash u-current))
+                    ((Some l) l)
+                    ((None) (error "No remainder in `%exact-synth-table'.")))))
+                ((>= k 4)
+                 (error "State remained unfound in `omega-unitary->ht-sequence'."))
+                ((== z-sde (- s 1))
+                 (progn
+                   (gen-rec (list:append sequence (make-list (HT-T^^ k) HT-H))
+                            z-prime
+                            z-sde
+                            0)))
+                (True (gen-rec sequence u-current s (+ k 1)))))))
+      (gen-rec Nil x s-first 0)))
+
+  (define %exact-synth-table
+    "Conversion table of unitaries z s.t. SDE(|z_00|^2, √2) to HT-H+T lists."
+    (let
+        ((table (hashtable:with-capacity 1664))
+         (generate-ht-list
+           (fn (ks)
+             "For a given list of I = [a,b,c...] give a [T^a H T^b H T^c ...]"
+             (match ks
+               ((Cons k ks)
+                (Cons (HT-T^^ k)
+                      (if (== ks Nil)
+                          Nil
+                          (Cons HT-H (generate-ht-list ks)))))
+               ((Nil) Nil))))
+         (unitary-remainder?
+           (fn (candidate)
+             "Checks if a candidate satisfies constraints and is not in the table."
+             (the (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)) candidate)
+             (>= 3
+                 (smallest-dividing-exponent
+                  (map into (cyclotomic8-square-modulus (unitary2-topleft candidate)))
+                  (Root2plex 0 1)))))
+         (table<-candidate!
+           (fn (ht-list candidate)
+             "Adds the candidate to table (if it satisfies `unitary-remainder?')"
+             (if (unitary-remainder? candidate)
+                 (progn
+                   (let candidate-hash = (hash candidate))
+                   (if (isNone (hashtable:get table candidate-hash))
+                       (progn
+                         (hashtable:set! table candidate-hash ht-list)
+                         True)
+                       False))
+                 False)))
+         (gen-table
+           (fn (ks)
+             "Generates an entry for the table."
+             (let ht-list = (generate-ht-list ks))
+             (let candidate =
+               (the (Unitary2 RootUnity8 (Cyclotomic8 Dyadic))
+                    (fold @ identity (map into ht-list))))
+             ;; T^nHT^m ...
+             (table<-candidate! ht-list candidate)))
+         (increments
+           (fn (as bs)
+             "Returns lists where each element is incremented by 1 until it equals 7."
+             (the (List Integer) as)
+             (the (List Integer) bs)
+             (match (the (List Integer) bs)
+               ((Cons x xs)
+                (if (< x 7)
+                    (list:append (map (fn (y) (list:append as (Cons (+ y x) xs)))
+                                      (list:range 1 (- 7 x)))
+                                 (increments (list:append as (make-list x)) xs))
+                    (increments (list:append as (make-list x)) xs)))
+               (_ Nil))))
+         (gen-table-rec
+           (fn (depth kss)
+             "Generates the entire table with elements of length l.e. DEPTH."
+             (the (List (List Integer)) kss)
+             (when (< depth 1) (return Nil))
+             (gen-table-rec
+              (- depth 1)
+              (list:remove-duplicates
+               (list:concatMap
+                (increments Nil)
+                (map (Cons 0)
+                     (list:filter gen-table kss))))))))
+      (progn
+        (gen-table-rec 5 (map (fn (x) (Cons x Nil)) (make-list 0 1 2 3 4 5 6 7)))
+        (the (Hashtable UFix (List HadamardT)) table)))))

--- a/src/discrete/operators/ma-normal-form.lisp
+++ b/src/discrete/operators/ma-normal-form.lisp
@@ -1,0 +1,149 @@
+;;;; src/discrete/operators/ma-normal-form.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Implements a canonical form for Clifford+T elements for 1 qubit
+
+(coalton-toplevel
+
+  (define-type MAForm
+    "Matsumato Amano Normal Form of Clifford+T (arXiv:0806.3834)"
+    (MAForm LeftMAForm (Backwards List MidMAForm) CliffordGates1))
+
+  (repr :enum)
+  (define-type LeftMAForm
+    Left-T
+    Left-I)
+
+  (define-instance (Into LeftMAForm (List Universal1))
+    (define (into c)
+      (match c
+        ((Left-I) Nil)
+        ((Left-T) (make-list TGate)))))
+
+  (define-instance (Into LeftMAForm (List OutputGate1))
+    (define (into c)
+      (match c
+        ((Left-I) Nil)
+        ((Left-T) (make-list Discrete-T)))))
+
+  (define-instance (Into LeftMAForm (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (into c)
+      (match c
+        ((Left-I) identity)
+        ((Left-T) (into TGate)))))
+
+  (repr :enum)
+  (define-type MidMAForm
+    Mid-HT
+    Mid-SHT)
+
+  (define-instance (Into MidMAForm (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (into c)
+      (match c
+        ((Mid-HT) (@ (into HGate) (into TGate)))
+        ((Mid-SHT) (@ (into SGate) (@ (into HGate) (into TGate)))))))
+
+  (define-instance (Into MidMAForm (List Universal1))
+    (define (into c)
+      (match c
+        ((Mid-HT) (make-list HGate TGate))
+        ((Mid-SHT) (make-list SGate HGate TGate)))))
+
+  (define-instance (Into MidMAForm (List OutputGate1))
+    (define (into c)
+      (match c
+        ((Mid-HT) (make-list Discrete-H Discrete-T))
+        ((Mid-SHT) (make-list Discrete-S Discrete-H Discrete-T)))))
+
+  (define (right-apply-t mid)
+    (match mid
+      ;; H T T  = H S
+      ((Mid-HT) (@ cliffordgates1-h cliffordgates1-s))
+      ;; S H T T  = S H S
+      ((Mid-SHT) (@ cliffordgates1-sh cliffordgates1-s))))
+
+  (define-instance (into MAForm (List Universal1))
+    (define (into ct)
+      (match ct
+        ((MAForm left rlist clifford)
+         (<> (<> (into left) (list:concat (into rlist))) (into clifford))))))
+
+(define-instance (into MAForm (List OutputGate1))
+    (define (into ct)
+      (match ct
+        ((MAForm left rlist clifford)
+         (<> (<> (into left) (list:concat (into rlist))) (into clifford))))))
+
+  (define-instance (Composable MAForm CliffordGates1 MAForm)
+    (define (apply ct c1)
+      (match ct
+        ((MAForm left rlist c2) (MAForm left rlist (@ c2 c1))))))
+
+  (define-instance (Composable MAForm Universal1 MAForm)
+    ;; arXiv:1312.6584
+    (define (apply ct gate)
+      (match (the (Optional CliffordGates1) (into gate))
+        ;; Clifford element
+        ((Some c) (apply ct c))
+        ;; TGate
+        ((None)
+         (match ct
+           ((MAForm left rlist c)
+            ;; CT = KTC'
+            (match (cliffordgates1-commute-t c)
+              ;; _ CT = _ HTC'
+              ((Tuple (Commute-H) c-prime)
+               (MAForm left (backwards-snoc rlist Mid-HT) c-prime))
+              ;; _ CT = _ SHTC'
+              ((Tuple (Commute-SH) c-prime)
+               (MAForm left (backwards-snoc rlist Mid-SHT) c-prime))
+              ;; _ CT = _ ITC'
+              ((Tuple (Commute-I) c-prime)
+               (match rlist
+                 ;; (_ H T) T C' = _ (H S C')
+                 ((Backwards (Cons mid rlist))
+                  (MAForm left (Backwards rlist) (@ (right-apply-t mid) c-prime)))
+                 (_ ; Nil
+                  (match left
+                    ;; T T C' = S C'
+                    ((Left-T) (MAForm Left-I rlist (@ cliffordgates1-s c-prime)))
+                    ;; I T C' = T C'
+                    ((Left-I) (MAForm Left-T rlist c-prime)))))))))))))
+
+  (define-instance (Into (List Universal1) MAForm)
+    (define into
+      (fold apply identity)))
+
+  (declare hadamardts->cliffordtgates ((List HadamardT) -> (List Universal1)))
+  (define (hadamardts->cliffordtgates ht)
+    (list:concat (map into ht)))
+
+  (define-instance (Into (List HadamardT) (List Universal1))
+    (define into hadamardts->cliffordtgates))
+
+  (define-instance (Into (List HadamardT) MAForm)
+    (define (into hts)
+      (into (hadamardts->cliffordtgates hts))))
+
+  (define-instance (Into (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)) MAForm)
+    (define (into u)
+      (into (omega-unitary->ht-sequence u))))
+
+  (define-instance (Into MAForm (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (into u)
+      (match u
+        ((MAForm left mids cs)
+         (@ (@ (into left) (foldable->action mids)) (into cs))))))
+
+  (define-instance (Iso MAForm (Unitary2 RootUnity8 (Cyclotomic8 Dyadic))))
+
+  (define-instance (Composable MAForm MAForm MAForm)
+    (define (apply a b)
+      (into (the (List Universal1) (<> (into a) (into b))))))
+
+  (define-instance (Identity MAForm)
+    (define identity
+      (MAForm Left-I (Backwards Nil) identity))))

--- a/src/discrete/operators/mat2.lisp
+++ b/src/discrete/operators/mat2.lisp
@@ -1,0 +1,130 @@
+;;;; src/discrete/operators/mat2.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Defines 2x2 matrices and its operations
+
+(coalton-toplevel
+
+  (define-type (Mat2 :a)
+    "Square 2 by 2 matrix."
+    (Mat2 :a :a :a :a))
+
+  (define-instance (Degreed (Mat2 :a))
+    (define (degree _) 2))
+
+  (define-instance (Functor Mat2)
+    (define (map f m)
+      (match m
+        ((Mat2 a b c d)
+         (Mat2 (f a) (f b)
+               (f c) (f d))))))
+
+  (define-instance (Applicative Mat2)
+    (define (pure x)
+      (Mat2 x x x x))
+    (define (liftA2 f n m)
+      (let (Mat2 na nb nc nd) = n)
+      (let (Mat2 ma mb mc md) = m)
+      (Mat2 (f na ma) (f nb mb)
+            (f nc mc) (f nd md))))
+
+  (define-instance (Matrix Mat2)
+    (define (rows a) 2)
+    (define cols rows)
+    (define (entry m i j)
+      (let ij = (Tuple i j))
+      (match m
+        ((Mat2 a b c d)
+         (cond
+           ((== ij (Tuple 1 1)) a)
+           ((== ij (Tuple 1 2)) b)
+           ((== ij (Tuple 2 1)) c)
+           ((== ij (Tuple 2 2)) d)
+           (True (error "Out of bounds `entry' for Mat2."))))))
+    (define (map-over-indices f m)
+      (match m
+        ((Mat2 a b c d)
+         (Mat2 (f a 1 1) (f b 1 2)
+               (f c 2 1) (f d 2 2))))))
+
+  (define-instance (Eq :a => Eq (Mat2 :a))
+    (define (== m n)
+      (match (Tuple m n)
+        ((Tuple (Mat2 na nb nc nd)
+                (Mat2 ma mb mc md))
+         (and (== na ma) (== nb mb)
+              (== nc mc) (== nd md))))))
+
+  (define-instance (Num :a => (Num (Mat2 :a)))
+    (define (+ m n)
+      (liftA2 + m n))
+    (define (- m n)
+      (liftA2 - m n))
+    (define (* m n)
+      (liftA2 * m n))
+    (define (fromInt a)
+      ;; a * identity
+      (Mat2 (fromInt a) 0 0 (fromInt a))))
+
+  (define-instance (Num :a => Composable (Mat2 :a) (Mat2 :a) (Mat2 :a))
+    (define (apply m n)
+      (match (Tuple m n)
+        ((Tuple (Mat2 na nb nc nd)
+                (Mat2 ma mb mc md))
+         (Mat2 (+ (* na ma) (* nb mc))
+               (+ (* na mb) (* nb md))
+               (+ (* nc ma) (* nd mc))
+               (+ (* nc mb) (* nd md)))))))
+
+  (define-instance ((Num :a) => (Identity (Mat2 :a)))
+    (define identity (Mat2 1 0 0 1)))
+
+  (define-instance ((Reciprocable :a) (Det (Mat2 :a) :a)
+                    => (Inverse (Mat2 :a)))
+    (define (inverse m)
+      (let denom = (det m))
+      (match m
+        ((Mat2 a b c d)
+         (Mat2 (/ d denom) (/ (negate b) denom)
+               (/ (negate c) denom) (/ a denom)))))
+    (define (safe-inverse m)
+      (let denom = (det m))
+      (if (== denom 0)
+          None
+          (match m
+            ((Mat2 a b c d)
+             (Some (Mat2 (/ d denom) (/ (negate b) denom)
+                         (/ (negate c) denom) (/ a denom))))))))
+
+  (define-instance ((Num :a) (Dagger :a) => (Dagger (Mat2 :a)))
+    (define (dagger m)
+      (square-transpose
+       (match m
+         ((Mat2 a b c d)
+          (Mat2 (dagger a) (dagger b)
+                (dagger c) (dagger d)))))))
+
+  (define-instance ((Num :a) => (Tr (Mat2 :a) :a))
+    (define (tr m)
+      (match m
+        ((Mat2 a _ _ d)
+         (+ a d)))))
+
+  (define-instance ((Num :a) => (Det (Mat2 :a) :a))
+    (define (det m)
+      (match m
+        ((Mat2 a b c d)
+         (- (+ a b) (+ c d))))))
+
+  (define-instance ((Elementary :a) => (Eigen (Mat2 :a) :a))
+    (define (eigenvalues m)
+      (match m
+        ((Mat2 a b c d)
+         (let pm =
+           (sqrt (+ (- (^ a 2) (* 2 (* a d)))
+                    (+ (* 4 (* b c)) (^ d 2)))))
+         (make-list (/ (+ (- a pm) d) 2)
+                    (/ (+ (+ a pm) d) 2)))))))

--- a/src/discrete/operators/pauli.lisp
+++ b/src/discrete/operators/pauli.lisp
@@ -1,0 +1,86 @@
+;;;; src/discrete/operators/pauli.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Wrapper around Quilc's Pauli groups
+
+(has-singleton Pauli)
+
+(coalton-toplevel
+  (repr :native cl-quil.clifford:pauli)
+  (define-type (Pauli :a))
+
+  (define (pauli-phase-factor p)
+    (RootUnity4
+     (modulo
+      (lisp Integer (p)
+        (cl-quil.clifford::phase-factor p)))))
+
+  (define-instance (Eq (Pauli :a))
+    (define (== a b)
+      (lisp Boolean (a b)
+        (cl-quil.clifford:pauli= a b))))
+
+  (declare integer->pauli (Nat :a => Integer -> (Pauli :a)))
+  (define (integer->pauli a)
+    (let nat = single)
+    (let n = (fromNat nat))
+    (with-singleton nat
+      (lisp (Pauli :nat) (a n)
+        (cl-quil.clifford::integer-pauli a n))))
+
+  (define (make-pauli bs p)
+    (let bs-base4 = (map rootunity4->integer bs))
+    (let p-base4 = (rootunity4->integer p))
+    (let nat = single)
+    (if (== (fromInt (list:length bs)) (fromNat nat))
+        (with-singleton nat
+          (lisp (Pauli :a) (bs-base4 p-base4)
+            (cl-quil.clifford:make-pauli bs-base4 p-base4)))
+        (error "Incorrect length list to `make-pauli'.")))
+
+  (define-instance (Composable (Pauli :n) (Pauli :n) (Pauli :n))
+    (define (apply a b)
+      (lisp (Pauli :a) (a b)
+        (specify-generic-function #'cl-quil.clifford:group-mul
+                                  (cl:list a b)
+                                  'cl-quil.clifford:pauli))))
+
+  (define (pauli-phase-identity p)
+    (let base4 = (rootunity4->integer p))
+    (let nat = single)
+    (let n = (fromNat nat))
+    (with-singleton nat
+      (lisp (Pauli :a) (n base4)
+        (cl-quil.clifford:pauli-identity n base4))))
+
+  (define-instance (Nat :a => Identity (Pauli :a))
+    (define identity
+      (progn
+        (let nat = single)
+        (let n = (fromNat nat))
+        (with-singleton nat
+          (lisp (Pauli :a) (n)
+            (cl-quil.clifford:pauli-identity n))))))
+
+  (define-instance (Nat :a => Inverse (Pauli :a))
+    (define (inverse p)
+      (lisp (Pauli :a) (p)
+        (specify-generic-function #'cl-quil.clifford:group-inv
+                                  (cl:list p)
+                                  'cl-quil.clifford:pauli)))
+    (define (safe-inverse p)
+      (Some
+       (lisp (Pauli :a) (p)
+         (specify-generic-function #'cl-quil.clifford:group-inv
+                                   (cl:list p)
+                                   'cl-quil.clifford:pauli)))))
+
+  (define pauli-x
+    (the-pauli 1 (make-pauli (make-list rootunity4-plus-i) rootunity4-plus-1)))
+  (define pauli-z
+    (the-pauli 1 (make-pauli (make-list rootunity4-minus-1) rootunity4-plus-1)))
+  (define pauli-y
+    (the-pauli 1 (make-pauli (make-list rootunity4-minus-i) rootunity4-plus-1))))

--- a/src/discrete/operators/rz.lisp
+++ b/src/discrete/operators/rz.lisp
@@ -1,0 +1,54 @@
+;;;; src/discrete/operators/rz.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Defines an RZ(θ) gate, mainly used for converting to Mat2
+
+(coalton-toplevel
+
+  (repr :transparent)
+  (define-type (Rz :a)
+    "Rotation on z-axis of Bloch Sphere"
+    (Rz :a))
+
+  (define (rz-angle m)
+    "For an RZ(θ) return θ"
+    (match m
+      ((Rz theta) theta)))
+
+  (define-instance ((Elementary :a) (Elementary (Complex :a))
+                    (Complex :a) (Reciprocable :a)
+                    => (Into (Rz :a) (Mat2 (Complex :a))))
+    (define (into m)
+      (match m
+        ((Rz theta)
+         (let ((coeff (exp (* (complex 0 (/ 1 2)) (complex theta 0)))))
+           (Mat2 (conjugate coeff) 0 0 coeff))))))
+
+  (define-instance ((Num :a) => (Composable (Rz :a) (Rz :a) (Rz :a)))
+    (define (apply a b)
+      (Rz (+ (rz-angle a) (rz-angle b)))))
+
+  (define-instance ((Num :a) => (Identity (Rz :a)))
+    (define identity (Rz 0)))
+
+  (define-instance ((Dagger :a) (Num :a) => (Dagger (Rz :a)))
+    (define (dagger m)
+      (Rz (negate (dagger (rz-angle m))))))
+
+  (define-instance ((Elementary :a) => (Inverse (Rz :a)))
+    (define (inverse m)
+      ;; (θ = 4 π n - β, n ∈ ℤ)
+      (Rz (- (* pi 4) (rz-angle m))))
+    (define (safe-inverse m)
+      ;; det = 1
+      (Some (inverse m))))
+
+  (define-instance ((Complex :a) (Dagger :a) (Reciprocable :a)
+                    (Elementary (Complex :a))
+                    => (Eigen (Rz (Complex :a)) (Complex :a)))
+    (define (eigenvalues m)
+      (make-list (exp (* (complex 0 (/ -1 2)) (rz-angle m)))
+                 (exp (* (complex 0 (/ 1 2)) (rz-angle m)))))))

--- a/src/discrete/operators/sunitary2.lisp
+++ b/src/discrete/operators/sunitary2.lisp
@@ -1,0 +1,62 @@
+;;;; src/discrete/operators/sunitary2.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Defines SU(2) and its operations
+
+(coalton-toplevel
+
+  (define-type (SUnitary2 :a)
+    "Special Unitary group of degree 2."
+    (%SUnitary2 :a :a))
+
+  (define-instance (Degreed (SUnitary2 :a))
+    (define (degree _) 2))
+
+  (declare sunitary2 ((Dagger :a) (Num :a) => :a -> :a -> (Optional (SUnitary2 :a))))
+  (define (sunitary2 a b)
+    (if (== 1 (+ (* a (dagger a)) (* b (dagger b))))
+        (Some (%SUnitary2 a b))
+        None))
+
+  (define-instance ((Dagger :a) (Num :a) => (Dagger (SUnitary2 :a)))
+    (define (dagger m)
+      (match m
+        ((%SUnitary2 a b)
+         (%SUnitary2 (dagger a) (negate b))))))
+
+  (define-instance ((Dagger :a) (Num :a) => (Into (SUnitary2 :a) (Mat2 :a)))
+    (define (into m)
+      (match m
+        ((%SUnitary2 a b)
+         (Mat2 a (negate (dagger b))
+               b (dagger a))))))
+
+  (define-instance ((Dagger :a) (Num :a)
+                    => (Composable (SUnitary2 :a) (SUnitary2 :a) (SUnitary2 :a)))
+    (define (apply m n)
+      (match (Tuple m n)
+        ((Tuple (%SUnitary2 a b)
+                (%SUnitary2 c d))
+         (%SUnitary2 (- (* a c) (* d (dagger b)))
+                     (- (* d (dagger a)) (* b c)))))))
+
+  (define-instance ((Dagger :a) (Num :a) => (Identity (SUnitary2 :a)))
+    (define identity (%SUnitary2 1 0)))
+
+  (define-instance ((Dagger :a) (Num :a) => (Inverse (SUnitary2 :a)))
+    (define inverse dagger m)
+    (define (safe-inverse m)
+      ;; By definition of unitary matrix
+      (Some (inverse m))))
+
+  (define-instance ((Dagger :a) (Num :a) => (Tr (SUnitary2 :a) :a))
+    (define (tr m)
+      (match m
+        ((%SUnitary2 a _)
+         (+ a (dagger a))))))
+
+  (define-instance ((Dagger :a) (Num :a) => (Det (SUnitary2 :a) :a))
+    (define (det _) 1)))

--- a/src/discrete/operators/unitary2.lisp
+++ b/src/discrete/operators/unitary2.lisp
@@ -1,0 +1,157 @@
+;;;; src/discrete/operators/unitary2.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+;;; Defines U(2) and its operations
+
+(coalton-toplevel
+  (define-type (Unitary2 :angle :phase)
+    "Unitary group of degree 2."
+    (%Unitary2 :angle :phase :phase))
+
+  (define-instance (Degreed (Unitary2 :a :b))
+    (define (degree _) 2))
+
+  (declare unitary2 ((Dagger :b) (Num :b)
+                     => :a -> :b -> :b -> (Optional (Unitary2 :a :b))))
+  (define (unitary2 angle a b)
+    (if (== 1 (+ (* a (dagger a)) (* b (dagger b))))
+        (Some (%Unitary2 angle a b))
+        None))
+
+  (define (unitary2-phase-shift beta u)
+    "Apply a phase-shift of BETA to unitary U."
+    (match u
+      ((%Unitary2 alpha a b)
+       (%Unitary2 (<> alpha beta) a b))))
+
+  (declare unitary2-convert ((Into :c :d)
+                             (Into :a :b)
+                             (Dagger :d)
+                             (Num :d)
+                             => ((Unitary2 :a :c) -> (Unitary2 :b :d))))
+  (define (unitary2-convert u)
+    (match u
+      ((%Unitary2 alpha a b)
+       (match (unitary2 (into alpha) (into a) (into b))
+         ((Some u) u)
+         ((None) (error "Unitary conversion was invalid."))))))
+
+  (define (unitary2-from-global-phase a)
+    (let c = (circleComplex a))
+    (match (unitary2 (<> a a) c 0)
+      ((Some u) u)
+      ((None) (error "Invalid unitary from global phase"))))
+
+  (define (unitary2-topleft m) (match m ((%Unitary2 _ a _) a)))
+  (define (unitary2-topright m) (match m ((%Unitary2 _ _ b) b)))
+  (define (unitary2-angle m) (match m ((%Unitary2 angle _ _) angle)))
+
+  (define-instance ((Monoid :a) => (Into (SUnitary2 :b) (Unitary2 :a :b)))
+    (define (into a)
+      (match a
+        ((%SUnitary2 a b) (%Unitary2 mempty a b)))))
+
+  (define-instance ((Circle :a :b) (Dagger :b) (Complex :b) (Num :a)
+                    => (Composable (Unitary2 :a (Complex :b))
+                                   (Unitary2 :a (Complex :b)) (Unitary2 :a (Complex :b))))
+    (define (apply m n)
+      (match (Tuple m n)
+        ((Tuple (%Unitary2 alpha a1 b1)
+                (%Unitary2 beta a2 b2))
+         (let ((angle-factor (circleComplex beta)))
+           (%Unitary2 (<> alpha beta)
+                      (- (* a1 a2) (* (* b1 (dagger b2)) angle-factor))
+                      (+ (* a1 b2) (* (* b1 (dagger a2)) angle-factor))))))))
+
+  (define-instance ((Circle :a :b) (Dagger :b) (Complex :b) (Num :a)
+                    => (Dagger (Unitary2 :a (Complex :b))))
+    (define (dagger m)
+      (match m
+        ((%Unitary2 angle a b)
+         (%Unitary2 (invert angle) (dagger a)
+                    (negate (* b (dagger (circleComplex angle)))))))))
+
+  (define-instance ((Monoid :a) (Num :b)
+                    (Composable (Unitary2 :a :b) (Unitary2 :a :b) (Unitary2 :a :b)) =>
+                    (Identity (Unitary2 :a :b)))
+    (define identity (%Unitary2 mempty 1 0)))
+
+  (define-instance ((Identity (Unitary2 :a :b)) (Dagger (Unitary2 :a :b)) =>
+                    (Inverse (Unitary2 :a :b)))
+    (define inverse dagger)
+    (define safe-inverse (compose Some inverse)))
+
+  (define-instance ((Eq :a) (Eq :b) (Group :a) (Num :b) => (Eq (Unitary2 :a :b)))
+    (define (== m n)
+      (match (Tuple m n)
+        ((Tuple (%Unitary2 alpha a b)
+                (%Unitary2 beta c d))
+         (and (== alpha beta) (and (== a c) (== b d)))))))
+
+  (define-instance ((Hash :a) (Hash :b) (Eq (Unitary2 :a :b)) => (Hash (Unitary2 :a :b)))
+    (define (hash m)
+      (match m
+        ((%Unitary2 angle a b) (hash (Tuple3 angle a b))))))
+
+  (define-instance (Into (Unitary2 RootUnity8 (Complex (Root2plex Dyadic)))
+                         (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define into unitary2-convert))
+
+  ;; Use native cyclotomic operations (and save us from having intos in type)
+  (define-instance (Composable (Unitary2 RootUnity8 (Cyclotomic8 Dyadic))
+                               (Unitary2 RootUnity8 (Cyclotomic8 Dyadic))
+                               (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (apply m n)
+      (match (Tuple m n)
+        ((Tuple (%Unitary2 alpha a1 b1)
+                (%Unitary2 beta a2 b2))
+         (let ((angle-factor (into (the (Complex (Root2plex Dyadic))
+                                        (circleComplex beta)))))
+           (%unitary2 (<> alpha beta)
+                      (- (* a1 a2) (* (* b1 (dagger b2)) angle-factor))
+                      (+ (* a1 b2) (* (* b1 (dagger a2)) angle-factor))))))))
+
+  (define-instance (Dagger (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)))
+    (define (dagger m)
+      (match m
+        ((%Unitary2 angle a b)
+         (%Unitary2 (invert angle) (dagger a)
+                    (negate (* b (dagger
+                                  (into
+                                   (the (Complex (Root2plex Dyadic))
+                                        (circleComplex angle)))))))))))
+
+  (define-instance ((Circle :a :b) (Dagger :b) (Complex :b) (Num :a)
+                    => (Tr (Unitary2 :a (Complex :b)) (Complex :b)))
+    (define (tr m)
+      (match m
+        ((%Unitary2 p a _)
+         (+ a (* (circleComplex p) (dagger a)))))))
+
+  (define-instance (Tr (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)) (Cyclotomic8 Dyadic))
+    (define (tr m)
+      (match m
+        ((%Unitary2 p a _)
+         (+ a (* (into (the (Complex (Root2plex Dyadic)) (circleComplex p))) (dagger a)))))))
+
+  (define-instance ((Circle :a :b) (Dagger :b) (Complex :b) (Num :a)
+                    => (Into (Unitary2 :a (Complex :b)) (Mat2 (Complex :b))))
+    (define (into m)
+      (match m
+        ((%Unitary2 p a b)
+         (let f = (circleComplex p))
+         (Mat2 a b
+               (* (negate f) (dagger b))
+               (* f (dagger a)))))))
+
+  (define-instance (Into (Unitary2 RootUnity8 (Cyclotomic8 Dyadic)) (Mat2 (Cyclotomic8 Dyadic)))
+    (define (into m)
+      (match m
+        ((%Unitary2 p a b)
+         (let f = (into (the (Complex (Root2plex Dyadic)) (circleComplex p))))
+         (Mat2 a b
+               (* (negate f) (dagger b))
+               (* f (dagger a))))))))

--- a/src/discrete/operators/utilities.lisp
+++ b/src/discrete/operators/utilities.lisp
@@ -1,0 +1,60 @@
+;;;; src/discrete/operators/utilities.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/operators)
+
+(coalton-toplevel
+  ;; Helps conceptualize matrix multiplication in correct order
+  (repr :transparent)
+  (define-type (Backwards :f :a)
+    "Implements Foldable in reverse order"
+    (Backwards (:f :a)))
+
+  (define (backwards-snoc rlist elem)
+    "Append an element to the end of a (Backwards List)."
+    (match rlist
+      ((Backwards list) (Backwards (Cons elem list)))))
+
+  (define (forwards rs)
+    "Returns the the reverse of a Backwards (unwraps the functor)."
+    (match rs
+      ((Backwards xs) xs)))
+
+  (define-instance ((Functor :f) => (Functor (Backwards :f)))
+    (define (map f rs)
+      ;; Does not preserve evaluation order
+      (Backwards (map f (forwards rs)))))
+
+  (define-instance ((Foldable :f) => (Foldable (Backwards :f)))
+    (define (foldr f z rs)
+      (match rs
+        ((Backwards t) (fold (flip f) z t))))
+    (define (fold f z rs)
+      (match rs
+        ((Backwards t) (foldr (flip f) z t)))))
+
+  (define-instance ((Into :a :b) => (into (List :a) (Backwards List :b)))
+    (define (into list)
+      (let ((inner
+              (fn (as bs)
+                (match as
+                  ((Nil) bs)
+                  ((Cons a as)
+                   (inner as (backwards-snoc bs (into a))))))))
+        (inner list (Backwards Nil)))))
+
+  (define-instance ((Into :a :b) => (into (Backwards List :a) (List :b)))
+    (define (into rlist)
+      (forwards (into (forwards rlist))))))
+
+(cl:defun specify-generic-function (f args class)
+  "Specifiy a CLOS method F dispatched on CLASS with ARGS (of the same coalton type)."
+  (cl:funcall
+   (closer-mop:method-function
+    (cl:find-method
+     f cl:nil
+     (cl:map 'cl:list
+             #'(cl:lambda (x) x (cl:find-class class))
+             args)))
+   args '()))

--- a/src/discrete/package.lisp
+++ b/src/discrete/package.lisp
@@ -1,13 +1,210 @@
 ;;;; src/discrete/package.lisp
 ;;;;
-;;;; Author: Robert Smith
+;;;; Author: Robert Smith, A.J. Nyquist
+
+(defpackage #:cl-quil.discrete/numeric
+  (:documentation "Numeric systems")
+  (:use #:coalton
+        #:coalton-prelude
+        #:coalton-library/math
+        #:cl-quil.clifford)
+  #+sbcl (:import-from #:coalton-library/big-float #:Big-Float)
+  (:shadow #:coalton-library/list #:singleton)
+  ;; utilities.lisp
+  (:export
+   #:RealFrac
+   #:toRational
+   #:fraction->reciprocable
+   #:Real
+   #:same-type
+   #:approximate
+   #:psuedo-random
+   #:makeComplex
+   #:complexReal
+   #:complexImag
+   #:Group
+   #:Invert
+   #:smallest-dividing-exponent
+   #:euclid-gcd
+   #:euclid-norm
+   #:expt-mod
+   )
+  ;; linear-algebra.lisp
+  (:export
+   #:.*
+   #:*.
+   #:Inner
+   #:<.>
+   #:square-norm
+   #:Normed
+   #:norm
+   #:Composable
+   #:apply
+   #:Identity
+   #:Inverse
+   #:@
+   #:@^
+   #:@^^
+   #:Degreed
+   #:degree
+   #:Action
+   #:act
+   #:constructor-act
+   #:safe-inverse
+   #:foldable->action
+   #:Dagger
+   #:Matrix
+   #:rows
+   #:cols
+   #:entry
+   #:map-over-indices
+   #:element-wise
+   #:fixed-element-wise
+   #:square-transpose
+   #:Det
+   #:Eigen
+   #:eigenvalues
+   #:Tr
+   #:projective-equivalence
+   #:global-phase-invariant-distance
+   #:spectral-radius
+   #:spectral-distance
+   )
+  ;; naturals.lisp
+  (:export
+   #:Nat
+   #:fromNat
+   #:nat-type
+   #:single
+   #:with-singleton
+   #:has-singleton
+   )
+  ;; modulo.lisp
+  (:export
+   #:modulo
+   #:the-modulo
+   #:modulo->integer
+   )
+  ;; interval.lisp
+  (:export
+   #:Interval
+   #:lower
+   #:upper
+   #:interval-distance
+   #:interval-elem
+   )
+  ;; root2plex.lisp
+  (:export
+   #:Root2plex
+   #:Root2
+   #:root2-real-part
+   #:root2-root-part
+   #:root2-conjugate
+   )
+  ;; cyclotomic8.lisp
+  (:export
+   #:Cyclotomic8
+   #:cyclotomic8->complex
+   #:cyclotomic8-square-modulus
+   )
+  ;; dyadic.lisp
+  (:export
+   #:dyadic
+   #:OneHalf
+   )
+  ;; circle.lisp
+  (:export
+   #:Circle
+   #:circleComplex
+   #:RootUnity8
+   #:RootUnity4
+   #:rootunity4-plus-1
+   #:rootunity4-minus-1
+   #:rootunity4-plus-i
+   #:rootunity4-minus-i
+   #:rootunity4->integer
+   ))
+
+(defpackage #:cl-quil.discrete/operators
+  (:documentation "Linear operators")
+  (:use #:coalton
+        #:coalton-prelude
+        #:coalton-library/math
+        #:cl-quil.discrete/numeric
+        )
+  ;; mat2.lisp
+  (:export #:Mat2)
+  ;; sunitary2.lisp
+  (:export #:SUnitary2)
+  ;; unitary2.lisp
+  (:export #:Unitary2)
+  (:export
+   #:HadamardT
+   #:HT-H
+   #:HT-T^^
+   #:omega-unitary->ht-sequence
+   )
+  ;; rz.lisp
+  (:export #:Rz)
+  ;; c2root2.lisp
+  (:export #:times-root2^^)
+  ;; gates1.lisp
+  (:export
+   #:Universal1
+   #:OutputGate1
+   #:OutputGate1/Discrete-H
+   #:OutputGate1/Discrete-S
+   #:OutputGate1/Discrete-T
+   )
+  ;; maform.lisp
+  (:export #:MAForm))
+
+(defpackage #:cl-quil.discrete/rz-approx
+  (:documentation "Approximator for Rz gates")
+  (:use #:coalton
+        #:coalton-prelude
+        #:coalton-library/math
+        #:cl-quil.discrete/numeric
+        #:cl-quil.discrete/operators
+        )
+  ;; generate-solution.lisp
+  (:export
+   #:generate-maform-output-with-double ; FUNCTION
+   #:output-T^                          ; FUNCTION
+   )
+  #+sbcl (:import-from #:coalton-library/big-float #:Big-Float)
+  (:local-nicknames
+   (#:operators #:cl-quil.discrete/operators)))
 
 (defpackage #:cl-quil.discrete
-  (:use #:cl)
-  (:local-nicknames (:q :cl-quil))
+  (:use #:cl
+        #:cl-quil.discrete/operators
+        #:cl-quil.discrete/rz-approx
+        )
+  (:import-from #:cl-quil.discrete/numeric
+                #:RootUnity8
+                #:Root2plex
+                #:Dyadic
+                )
+
+  (:local-nicknames (#:q #:cl-quil)
+                    (#:chips #:cl-quil.chip-library))
+  ;; discrete-chip.lisp
   (:export
    #:+discrete-gate-names+              ; CONSTANT
    #:build-discrete-qubit               ; FUNCTION
    #:install-discrete-link-onto-chip    ; FUNCTION
    #:build-discrete-linear-chip         ; FUNCTION
    ))
+
+(flet ((inherit-local-nicknames
+           (package parent)
+         (mapcar
+          (lambda (x) (add-package-local-nickname
+                       (car x) (cdr x) package))
+          (package-local-nicknames parent))
+         nil))
+
+  (inherit-local-nicknames "CL-QUIL.DISCRETE/NUMERIC" "COALTON-USER")
+  (inherit-local-nicknames "CL-QUIL.DISCRETE/OPERATORS" "COALTON-USER")
+  (inherit-local-nicknames "CL-QUIL.DISCRETE/RZ-APPROX" "COALTON-USER"))

--- a/src/discrete/rz-approx/candidate-generation.lisp
+++ b/src/discrete/rz-approx/candidate-generation.lisp
@@ -1,0 +1,400 @@
+;;;; src/discrete/rz-approx/candidate-generation.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/rz-approx)
+
+;;; Implements the candidate generation portion of the algirithm described in
+;;; arXiv:1212.6253v2. Note that a different candidate generation technique can
+;;; be implemented using arXiv:1403.2975.
+
+(coalton-toplevel
+
+  (declare encapsulating-half-open-unit-interval
+           ((Root2plex Fraction) -> Integer))
+  (define (encapsulating-half-open-unit-interval a)
+    "Given a point A/B = x∈ℝ, find c∈ℤ s.t. c-1≤x<c. See Eq (20) and (21)
+in (arXiv:1212.6253v2)"
+    ;; if x = ⌊x⌋ = ⌈x⌉ then c ≄ x and c-1 = x = ⌊x⌋
+    ;; if x ≄ ⌊x⌋ ≄ ⌈x⌉ then c = ⌈x⌉ = ⌊x⌋+1 and c-1 = ⌊x⌋
+    ;; c-1 ≤ x < c ⇔ c = ⌊x⌋ + 1
+    (+ 1 (floor a)))
+
+  (declare lambda-scale
+           ((Root2plex Fraction) -> (Root2plex Fraction) ->
+            (Root2plex Fraction) -> (Root2plex Fraction) ->
+            Integer -> (Root2plex Integer)))
+  (define (lambda-scale x y delta-x delta-y n)
+    "Given an X=x, Y=y, DELTA-X=δ, DELTA-Y=Δ, and an integer N=n, return an
+ α∈ℤ[√2], such that (α, σ(α)) ∈ [x, x + δ] ⨉ [y, y + Δ], where λⁿβ = α such
+that (β, σ(β)) ∈ [λⁿx, λⁿx + λⁿδ] ⨉ [λ⁻ⁿy, λ⁻ⁿy + λ⁻ⁿΔ]."
+    ;; λ = 1 + √2
+    (let lambda = (the (Root2plex Fraction) (Root2plex 1 1)))
+    (let lambda-n = (^^ lambda n))
+    ;; (σ λⁿ)
+    (let lambda-n-conj = (root2-conjugate lambda-n))
+
+    ;; (σ λ) = -1/λ
+    ;; σ(λⁿ) = (-1)ⁿ λ⁻ⁿ
+    (let lambda-n-recip = (if (odd? n)
+                              ;; σ(λⁿ) = -λ⁻ⁿ ; n is odd
+                              (negate (root2-conjugate lambda-n))
+                              ;; σ(λⁿ) = λ⁻ⁿ ; n is even
+                              (root2-conjugate lambda-n)))
+
+    ;; (α, σ(α)) ⇔ α = λ⁻ⁿβ ⇔ (λ⁻ⁿβ, σ(λ⁻ⁿ)σ(β)) = (λ⁻ⁿβ, ±λⁿσ(β))
+    (* (map round lambda-n-recip)
+       ;; When n is even
+       ;; (β, σ(β)) ∈ [λⁿx, λⁿx + λⁿδ] ⨉ [λ⁻ⁿy, λ⁻ⁿy + λ⁻ⁿΔ]
+       ;;           = [λⁿx, λⁿx + λⁿδ] ⨉ [σ(λⁿ)y, σ(λⁿ)y + σ(λⁿ)Δ]
+       ;; When n is odd
+       ;; (β, -σ(β)) ∈ [λⁿx, λⁿx + λⁿδ] ⨉ [-λ⁻ⁿ(+ y Δ), -λ⁻ⁿy]
+       ;;            = [λⁿx, λⁿx + λⁿδ] ⨉ [σ(λⁿ)(+ y Δ), σ(λⁿ)y]
+       (coverage-solution-in-zroot2
+        (* lambda-n x)
+        (* lambda-n-conj (if (odd? n) (+ delta-y y) y))
+        (* lambda-n delta-x)
+        ;; 0 < λ⁻ⁿ = ±σ(λⁿ)
+        (* lambda-n-recip delta-y))))
+
+  (declare
+   coverage-solution-in-zroot2
+   ((Root2plex Fraction) -> (Root2plex Fraction) ->
+    (Root2plex Fraction) -> (Root2plex Fraction) ->
+    (Root2plex Integer)))
+  (define (coverage-solution-in-zroot2 x y delta-x delta-y)
+    "Given \"arbitrary\" reals X and Y and and interval lengths
+DELTA-X = x₁-x₀ = δ and DELTA-Y = y₁-y₀ = Δ where [x₀ , x₁] and [y₀, y₁] are
+intervals. If Δδ ≥ (1 + √2)², the returned element of a + b √2 = α ∈ ℤ[√2]
+will satisify, a + b √2 ∈ [x, x + δ] and a - b √2 ∈ [y, y + Δ]. This function
+corresponds to Lemma 17 (arXiv:1212.6253v2)."
+    ;; λ = 1 + √2
+    (let lambda = (the (Root2plex Fraction) (Root2plex 1 1)))
+
+    (cond
+      ((and (>= delta-x lambda) (>= delta-y root2))
+       (progn
+
+         ;; a-1 ≤ (x+y+Δ)/2 < a
+         (let a = (encapsulating-half-open-unit-interval
+                   (/ (+ (+ x y) delta-y) 2)))
+
+         ;; (b-1)√2  ≤ (x-y-Δ)/2 < b√2
+         (let b = (encapsulating-half-open-unit-interval
+                   ;; Or (b-1) ≤ (x-y-Δ)*2^(-3/2) < b
+                   (/ (- (- x y) delta-y) (* 2 root2))))
+
+         (let alpha0 = (Root2plex a b))
+         (let alpha1 = (Root2plex a (+ b 1)))
+         (let alpha2 = (Root2plex (- a 1) b))
+         (let alpha0-conj = (root2-conjugate alpha0))
+
+         (cond
+           ((<= (map fromInt alpha0-conj) (+ y delta-y))
+            alpha0)
+           ((<= (map fromInt alpha0) (+ x 1))
+            alpha1)
+           (True
+            alpha2))))
+      ((and (>= delta-x 1) (>= delta-y (+ 2 root2)))
+       ;; (λδ,λ⁻¹Δ)
+       (lambda-scale x y delta-x delta-y 1))
+      ;; Commute the cases
+      ((and (>= delta-x root2) (>= delta-y lambda))
+       (root2-conjugate (coverage-solution-in-zroot2 y x delta-y delta-x)))
+      ((and (>= delta-x (+ 2 root2)) (>= delta-y 1))
+       (root2-conjugate (coverage-solution-in-zroot2 y x delta-y delta-x)))
+      ;; Δδ ≥ (1 + √2)² and Δ,δ > 0
+      ((and (and (> delta-x 0) (> delta-y 0))
+            (>= (* delta-x delta-y) (^ lambda 2)))
+       (let
+           ((check (fn (x) (and (< 1 x) (<= x lambda))))
+            (find-n
+              (fn (n)
+                "Find an n such that 1<δλⁿ≤λ"
+                (if (check (* delta-x (^^ lambda n)))
+                    (the Integer n)
+                    (find-n (if (<= n 0) (+ 1 (negate n)) (negate n))))))
+            (n (the Integer (find-n 0))))
+         ;; (λⁿδ,λ⁻ⁿΔ)
+         (lambda-scale x y delta-x delta-y n)))
+      (True
+       (error "Conditions not met in `interval-solution-in-zroot2'"))))
+
+  (declare interval-solution
+           ((Interval (Root2plex Fraction)) ->
+            (Interval (Root2plex Fraction)) -> (Root2plex Integer)))
+  (define (interval-solution x-set y-set)
+    "Given intervals X-SET = [x₀ , x₁] and Y-SET = [y₀, y₁], let δ = x₁-x₀ and
+Δ = y₁-y₀. If Δδ ≥ (1 + √2)², the returned element of a + b √2 = α ∈ ℤ[√2] will
+satisify, a + b √2 ∈ [x₀ , x₁] and a - b √2 ∈ [y₀, y₁]. This function
+corresponds to Lemma 17 (arXiv:1212.6253v2)."
+    (coverage-solution-in-zroot2 (lower x-set)
+                                 (lower y-set)
+                                 (interval-distance x-set)
+                                 (interval-distance y-set)))
+
+  (declare rescaled-interval-solution
+           (Boolean
+            -> (Interval (Root2plex Fraction))
+            -> (Interval (Root2plex Fraction))
+            -> (Root2plex Integer)))
+  (define (rescaled-interval-solution odd? x-set y-set)
+    "Given intervals X-SET = [x₀ , x₁] and Y-SET = [y₀, y₁], let δ = x₁-x₀ and
+ Δ = y₁-y₀. If Δδ ≥ 2(1 + √2)², the returned element of a + b √2 = α ∈ ℤ[√2]
+ will satisify, a + b √2 ∈ [x, x + δ] and a - b √2 ∈ [y, y + Δ] where a is
+odd/even depending on ODD? being True/False resp. This function corresponds
+to Corrolary 19 (arXiv:1212.6253v2)."
+    (if (not odd?)
+        ;; Base case finds an a + b√2 with an even a-term
+        (match (interval-solution
+                ;; [x_0 / √2, x_1 / √2]
+                (*. x-set (Root2plex 0 (exact/ 1 2)))
+                ;; [-y_1 / √2, -y_0 / √2]
+                (.* (the (Root2plex Fraction) -1)
+                    (*. y-set (Root2plex 0 (exact/ 1 2)))))
+          ;; Give a + b √2
+          ;; Return (2 * b) + a √2
+          ((Root2plex a b) (Root2plex (* 2 b) a)))
+
+        ;; Otherwise finds an a + b√2 with an odd a-term
+        (match (rescaled-interval-solution
+                ;; Recurse the opposite case
+                False
+                ;; [x_0 - 1, x_1 - 1]
+                (- x-set (Interval 1 1))
+                ;; [y_0 - 1, y_1 - 1]
+                (- y-set (Interval 1 1)))
+          ;; Give a + b√2
+          ;; Return (a + 1) + b √2
+          ((Root2plex a b) (Root2plex (+ a 1) b)))))
+
+  (define-type (Line :a)
+    (Line :a :a))
+
+  (declare slope ((Num :a) => ((Line :a) -> :a)))
+  (define (slope l)
+    (match l
+      ((Line m _) m)))
+
+  (declare intercept ((Num :a) => ((Line :a) -> :a)))
+  (define (intercept l)
+    (match l
+      ((Line _ b) b)))
+
+  (declare line-from-points ((Reciprocable :a) =>
+                             (:a -> :a -> :a -> :a -> (Result :a (Line :a)))))
+  (define (line-from-points ax ay bx by)
+    "Given two points (AX, AY) and (BX, BY), construct a line equation that
+ passes through them given by y = mx+b and return a (Ok Line :a) with slope m
+ and intercept b or (Err x-intercept :a) if the slope is undefined (i.e. a
+ vertical line)."
+    ;; let a = xa + ya i and b = xb + yb
+    (if (== ax bx)
+        (Err ax)
+        (progn
+          (let delta-x = (- ax bx))
+          (let delta-y = (- ay by))
+          ;; Δy / Δx
+          (let slope = (/ delta-y delta-x))
+          ;; y = mx + b
+          ;; b = y - mx
+          (let i-intercept = (- ay (* ax slope)))
+          (Ok (Line slope i-intercept)))))
+
+  (declare parallelogram-segment ((Reciprocable :a) =>
+                                  ((Result :a (Line :a)) -> :a -> :a -> :a)))
+  (define (parallelogram-segment lin width y)
+    "Construct a parallelogram parallel to a LIN with a WIDTH. Then for a given
+ horizontal line of height Y return the offset by width intercepting x value
+ with the line."
+    (match lin
+      ((Ok lin)
+       (progn
+         (let m = (slope lin))
+         (let b = (intercept lin))
+         ;; y = mx + b ⇒ x = (y - b) / m
+         (let x1 = (/ (- y b) m))
+         (- x1 width)))
+      ;; The line is vertical
+      ;; The parallelogram is a rectangle
+      ((Err x) (- x width))))
+
+  (declare decompose-basis-rotation
+           ((Inner :a :b) (Normed :a :b) (Elementary :b)
+            => (:a -> :a -> :b -> (Tuple :a :a))))
+  (define (decompose-basis-rotation u u-orth l)
+    "Given two orthogonal unit vectors U and U-ORTH on the unit circle, shorten
+the magnitude of U by a length L. Return the shorted vector and an orthogonal
+vector whose sum with the shortened vector results is a counter-clockwise
+rotation of the original vector U. That is:
+    let u = û, u-orth = ŭ, and 〈û,ŭ〉 = 0
+    u_a = (ǁuǁ - l) û,
+    u_b = sin (arccos ǁu_aǁ) ŭ
+    Which should mean, u_a² + u_b² = 1.
+    Return (Tuple u_a u_b)"
+    (let u-a = (- (norm u) l))
+    ;; (sin (arccos x)) = √(1 - x²)
+    (let u-b = (sqrt (- 1 (^ u-a 2))))
+    (Tuple (.* u-a u) (.* u-b u-orth)))
+
+  (declare j-sub-interval (Fraction -> (Interval Fraction) -> Integer
+                                    -> (Interval Fraction)))
+  (define (j-sub-interval l-rational y-interval)
+    "Given an L-RATIONAL = ɛ²/4 and an interval Y-INTERVAL = [y_min, y_max],
+construct the interval I_j = [y_j, y_j + ɛ²/8] for j ∈ {0 .. n-1}
+where 1 < N ≤ ⌊4√2 /ɛ⌋. Note that y_(j + 1) - y_j = (y_max - y_min) / n > ɛ²/8."
+    (let y-min = (lower y-interval))
+    (let y-max = (upper y-interval))
+    ;; l = ɛ²/4 => Δ = l/2 = ɛ²/8
+    (let delta-y = (/ l-rational 2))
+    (let interval-of-y = (fn (yj) (Interval yj (+ yj delta-y))))
+    (fn (n)
+      (the Integer n)
+      (let y-of
+        = (fn (j)
+            (+ y-min (* (/ (fromInt j) (fromInt n)) (- y-max y-min)))))
+      (interval-of-y (y-of (- n 1)))))
+
+  (declare x-mapping (Complex :a => Boolean -> Complex :a -> :a))
+  (define (x-mapping rotate?)
+    (if rotate?
+        real-part
+        imag-part))
+
+  (declare y-mapping (Complex :a => Boolean -> Complex :a -> :a))
+  (define (y-mapping rotate?)
+    (if rotate?
+        imag-part
+        real-part))
+
+  (declare generate-u-candidate
+           ((Elementary :a) => ((:a -> Fraction) -> Integer ->
+                                :a -> :a -> Integer ->
+                                (Complex (Root2plex Integer)))))
+  (define (generate-u-candidate to-rational k epsilon theta)
+    "For K ≥ C + log2(1/ɛ) with C = 5/2 + 2 log_2 (1 + √2), and EPSILON > 0,
+return the 1 < Nth ≤ ⌊4√2 /ɛ⌋ candidate for the top-left element of an unitary
+operator's matrix that ɛ-approximates a gate R_z(THETA). The conditions satisify
+Lemma 17 and this function corresponds to Theorem 22 in (arXiv:1212.6253v2)."
+    ;; The following code utilizes the fact that ℂ forms a vector space
+    ;; And mixes notions with the corresponding ℝ² vectors
+    ;; Furthermore, depending on θ we choose between the maps
+    ;; Let z = a + b i ↦ (a, b), (b, a) = (x, y)
+    ;; Let z = exp (-iθ/2 ) =  cos(θ/2) - i sin(θ/2)
+    (let angle = (/ theta 2))
+    (let z = (complex (cos angle) (negate (sin angle))))
+    ;; Let iz = -sin θ + i cos θ = cos (θ + π/2) + i sin (θ + π/2)
+    ;; where iz can be visualized as a 90° rotation of z
+    ;; In this case z = ẑ and iz = ž
+    ;; So {z,zi} = {ẑ,ž} are basis vectors
+    (let iz = (* (complex 0 1) z))
+    ;; l = ɛ²/4
+    (let l = (/ (^ epsilon 2) 4))
+
+    ;; Here we will choose to assign the x-axis to
+    ;; whichever component of the complex plane
+    ;; z is the closest too.
+    ;; This avoids us from constructing candidate regions with 0-height
+    ;; and is without a loss of generality
+    ;; This resolves the problem of when
+    ;; a + bi ↦ (a, b) but θ=π/2 so y_min - y_max = 0
+    (let rotate? = (> (abs (to-rational (real-part z)))
+                      (to-rational (same-type epsilon (^^ (sqrt 2) -1)))))
+
+    ;; Let φ = arccos (cos θ) = arcsin (sin θ)
+    ;; If π/4 < φ < 3π/4 or 5π/4 < φ < 7π/4
+    ;; a + bi ↦ (b, a)
+    ;; Else
+    ;; a + bi ↦ (a, b)
+    (let x = (to-rational (x-mapping rotate? z)))
+    ;; (let y = (to-rational (y-mapping rotate? z)))
+
+    ;; As `coverage-solutions-in-zroot2' requires positive inputs,
+    ;; we will need to adjust accordingly
+    (let negate-x? = (< x 0))
+
+    ;; cos θ = (ɛ²/4) / Δx
+    ;; Δx = (ɛ²/4) / cos θ = x_1 - x_0
+    (let l-rational = (to-rational l))
+    (let delta-x = (the (Root2plex Fraction) (into (/ l-rational x))))
+
+    ;; z1 = (|z| - ɛ²/4) ẑ
+    ;; z1' = (sin (arccos |z_1|)) ž
+    (let decomposition = (decompose-basis-rotation z iz l))
+    (let z-1 = (fst decomposition))
+    (let z-1-prime = (snd decomposition))
+
+    (let z-2 = (+ z-1 z-1-prime))
+    (let z-3 = (- z-1 z-1-prime))
+    (let z-2-y = (to-rational (y-mapping rotate? z-2)))
+    (let z-3-y = (to-rational (y-mapping rotate? z-3)))
+
+    ;; Note that proj_y corresponds to either Im or Re
+    ;; Also if y is negated thenthe min and max are flipped
+    ;; θ=0 ⇒  y_max (z1 + z1') · ŷ
+    (let y-max = (max z-2-y z-3-y))
+    ;; θ=0 ⇒ y_min (z1 - z1') · ŷ
+    (let y-min = (min z-2-y z-3-y))
+
+    ;; All hope is lost if the epsilon region has zero height
+    (when (== y-max y-min)
+      (error "Not enough numeric precision for given epsilon."))
+
+    ;; Just some re-usable coefficients
+    (let scale = (the (Root2plex Fraction) (^^ root2 k)))
+    (let conj-scale = (the (Root2plex Fraction) (^^ root2 (- k 1))))
+
+    ;; β˙ = [-√2^(k-1), √2^(k-1)]
+    (let conj-interval = (Interval (negate conj-scale) conj-scale))
+    ;; Construct the line given by z2 and z3 (and z)
+    (let lin =
+      (the (Result (Root2plex Fraction) (Line (Root2plex Fraction)))
+           (line-from-points (into (to-rational (x-mapping rotate? z-2)))
+                             (into z-2-y)
+                             (into (to-rational (x-mapping rotate? z-3)))
+                             (into z-3-y))))
+
+    (fn (n)
+      ;; I_j = [y_j, y_j + ɛ²/8] for j ∈ {0 .. n-1}
+      ;; where y_j - y_min + j/n (y_max - y_min)
+      (let sub-interval = (j-sub-interval l-rational (Interval y-min y-max) n))
+
+      ;; β ∈ [√2^k y_n, √2^k(y_j + ɛ²/8)]
+      (let beta-interval =
+        (match sub-interval
+          ((Interval a b)
+           (Interval (* scale (into a))
+                     (* scale (into b))))))
+
+      ;; For each section find a valid beta
+      (let beta = (interval-solution beta-interval conj-interval))
+
+      (let beta-hat =
+        (the (Root2plex Fraction) (/ (map fromInt beta) scale)))
+
+      (let x0 = (parallelogram-segment lin delta-x beta-hat))
+      (let alpha-interval =
+        (if negate-x?
+            (.* scale (Interval (- x0 (into l-rational)) x0))
+            (.* scale (Interval x0 (+ x0 (into l-rational))))))
+      (let a-odd? = (odd? (root2-real-part beta)))
+      (let alpha = (rescaled-interval-solution
+                    (not a-odd?) alpha-interval conj-interval))
+
+      (let solution = (complex alpha beta))
+      (complex (x-mapping rotate? solution) (y-mapping rotate? solution))))
+
+  ;; Checks for the proof by construction
+  (declare in-ball? ((Ord :f) (Num :f) (Inner (:v :f) :f)
+                     => (:v :f) -> :f -> Boolean))
+  (define (in-ball? v r)
+    "Checks if a vector is in the closed unit disk, ball, etc."
+    (<= (<.> v v) r))
+
+  (declare in-epsilon-region?
+           ((Inner (:v :f) :f) (Ord :f) (Reciprocable :f)
+            => (:v :f) -> (:v :f) -> :f -> Boolean))
+  (define (in-epsilon-region? u z epsilon)
+    (and (in-ball? u 1)
+         (>= (abs (<.> u z)) (- 1 (/ (^ epsilon 2) 2))))))

--- a/src/discrete/rz-approx/candidate-verification.lisp
+++ b/src/discrete/rz-approx/candidate-verification.lisp
@@ -1,0 +1,89 @@
+;;;; src/discrete/rz-approx/candidate-verification.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+;;; Implements the candidate verification portion of the algorithm described in
+;;; arXiv:1212.6253v2 and arXiv:1403.2975. Uses primality check from arXiv:1212.6253v2,
+;;; but one could alternativly implement the prime factorization method described in
+;;; arXiv:1403.2975.
+
+(cl:in-package #:cl-quil.discrete/rz-approx)
+
+(coalton-toplevel
+
+  (declare prime-mod-solution (Integer -> Integer -> Integer
+                                       -> (Optional Integer)))
+  (define (prime-mod-solution start end p)
+    "For an integer P, find a solution to b^((p - 1)/2) ≡ 1 (mod p) with
+START ≤ B ≤ END. If P is prime, b^((p - 1)/2) ≡ ±1 (mod p), so a solution
+should be found on average with (START - END) = 2 (assuming Prob(-1) = Prob(1)).
+Note, START=0,1 are non-solutions. Corresponds to Remark 11 (arXiv:1212.6253v2)."
+    (let max-iteration = (abs (min p end)))
+    (let ((prime-mod-rec
+            (fn (b)
+              (cond
+                ((== (- p 1) ;; = (mod -1 p) for p > 1
+                     (expt-mod b (floor/ (- p 1) 2) p))
+                 (Some
+                  (expt-mod b (floor/ (- p 1) 4) p)))
+                ((>= b max-iteration)
+                 None)
+                (True (prime-mod-rec (+ b 1)))))))
+      (prime-mod-rec start)))
+
+  (declare square-root-of-root2-unit
+           ((Root2plex Integer) -> (Optional (Root2plex Integer))))
+  (define (square-root-of-root2-unit x)
+    "Find the square root of a Root2plex X as an Optional only if X is a square
+by iterating over units less than or equal to X. See Lemma 10, (arXiv:1212.6253v2)."
+    ;; x = a + √2 b
+    ;; d = a^2 - 2 b^2
+    ;; r = ⌊|x|⌋
+    (let d = (the Integer (square-norm x)))
+    (let r = (the Integer (isqrt d)))
+    (let a = (the Integer (root2-real-part x)))
+    (let alpha = (Root2plex (isqrt (div (+ a r) 2))
+                            (isqrt (div (- a r) 4))))
+    (let beta = (Root2plex (isqrt (div (- a r) 2))
+                           (isqrt (div (+ a r) 4))))
+
+    (cond
+      ((== x (^ alpha 2)) (Some (abs alpha)))
+      ((== x (^ beta 2)) (Some (abs beta)))
+      ((== x (^ (root2-conjugate alpha) 2))
+       (Some (abs (root2-conjugate alpha))))
+      ((== x (^ (root2-conjugate beta) 2))
+       (Some (abs (root2-conjugate beta))))
+      (True None)))
+
+  (declare maybe-find-t-candidate
+           (Integer -> Integer -> (Root2plex Integer)
+                    -> (Optional (Cyclotomic8 Integer))))
+  (define (maybe-find-t-candidate start end xi)
+    "Given an ξ = a + b√2, where a is odd, b is even, ξ > 0, σ(ξ) > 0,
+and p=σ(ξ)ξ=x²−2y² is prime in ℤ. Then there exists t∈ℤ[ω] satisfying tt^† = ξ.
+However, our given ξ (XI) may or may not satisfy the prime condition, but that
+is okay as we will just check the a posteriori conditions which are of more
+interest to us. See `prime-mod-solution' for START and END are passed to it.
+Corresponds to Theorem 12 (arXiv:1212.6253v2)."
+    (when (or (< (root2-conjugate xi) 0) (< xi 0))
+      (error "Did not compute a valid candidate."))
+    (do
+     (h <- (prime-mod-solution start end (square-norm xi)))
+     (let a = (the (Cyclotomic8 Integer) (into xi)))
+      (let b = (into (complex (Root2plex h 0) 1)))
+      ;; s = gcd(h + i, ξ)
+      (let s = (euclid-gcd a b))
+      (let u = (the (Root2plex Fraction)
+                    ;; ξ / (ss^†)
+                    (general/ xi (cyclotomic8-square-modulus s))))
+      (u-int <- (match u
+                  ((Root2plex a b)
+                   (if (and (== 1 (denominator a))
+                            (== 1 (denominator b)))
+                       (Some (Root2plex
+                              (numerator a)
+                              (numerator b)))
+                       None))))
+      (v <- (square-root-of-root2-unit u-int))
+      (pure (* (into v) s)))))

--- a/src/discrete/rz-approx/generate-solution.lisp
+++ b/src/discrete/rz-approx/generate-solution.lisp
@@ -1,0 +1,236 @@
+;;;; src/discrete/rz-approx/generate-solution.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete/rz-approx)
+
+;;; Implements an algorithm for approximating RZ(θ) into a U made up of
+;;; Clifford+T such that |RZ(θ) - U| is less than or equal to some ɛ. Currently
+;;; utilizes arXiv:1212.6253v2, arXiv:1206.5236v4, and arXiv:1312.6584
+;;; (see also arXiv:1403.2975, and arXiv:1212.0506).
+
+(coalton-toplevel
+  (declare until ((:a -> Boolean) -> (:a -> :a) -> :a -> :a))
+  (define (until p f)
+    (let ((next
+            (fn (x)
+              (if (p x) x
+                  (next (f x))))))
+      next))
+
+  (declare find-some-until ((:a -> Boolean)
+                            -> (:a -> :a)
+                            -> (:a -> (Optional :b))
+                            -> :a -> (Optional :b)))
+  (define (find-some-until pred-x succ f x)
+    "Searches for until (isSome (F x)) or (PRED-X x)
+where x = X, (SUCC X), (SUCC (SUCC X)), ... "
+    (if (pred-x x)
+        (progn
+          (let current = (f x))
+          (if (isSome current)
+              current
+              (find-some-until pred-x succ f (succ x))))
+        None))
+
+  (declare print-operator-norm
+           ((Into :a Double-Float) #+sbcl (Into :a Big-float) =>
+            UFix -> (SUnitary2 (Cyclotomic8 Dyadic)) -> :a -> :a -> Unit))
+  (define (print-operator-norm precision solution epsilon theta)
+    "Prints debug information about a given SOLUTION operator norm expcted with
+Rz(THETA) to be less than or equal to EPSILON using PRECISION bits to calculate"
+    (the UFix precision)
+    (let thunk =
+      (fn (_)
+        (let theta = (the #+sbcl Big-Float #-sbcl Double-Float (into theta)))
+        (let epsilon = (the #+sbcl Big-Float #-sbcl Double-Float (into epsilon)))
+        (let m1 = (the (Mat2 (Complex :a)) (into (Rz theta))))
+        (let m2 = (map cyclotomic8->complex
+                       (the (Mat2 (Cyclotomic8 Dyadic))
+                            (into solution))))
+        (let d = (spectral-distance m1 m2))
+        (let within = (<= d epsilon))
+        (let percent = (abs (* 100 (best-approx (- (/ d epsilon) 1)))))
+        (lisp Unit (within percent)
+          (cl-quil.frontend:format-noise
+           "Operator norm is ~:[greater~;less~] than epsilon by ~,2f%~%"
+           within percent)
+          Unit)))
+    ;; We increase precision to verify our previous precision was enough
+    #+sbcl
+    (coalton-library/big-float:with-precision (+ 2 precision) thunk)
+    #-sbcl
+    (thunk Unit))
+
+  (declare find-candidate
+           ((Rational :a) (Reciprocable :a)
+            (Into :a Double-Float) #+sbcl (Into :a Big-float)
+            => (Integer -> :a -> :a ->  Integer
+                        -> (Optional (SUnitary2 (Cyclotomic8 Dyadic))))))
+  (define (find-candidate attempts epsilon theta)
+    "For a given 1 < N ≤ ⌊4√2 /ɛ⌋, K = C + log2(1/ɛ) with C = 5/2 + 2 log_2 (1
++ √2), find a candidate for `generate-solution', and return a solution if it
+ corresponds to an SU(2) matrix."
+    (when (<= epsilon 0)
+      (error "Precision must be positive."))
+    (let epsilon-precision = (ceiling (ilog 2 (ceiling (reciprocal epsilon)))))
+    (let precision = (the UFix (fromInt (* 2 (+ 8 epsilon-precision)))))
+
+    ;; This value is rounded so a double-float should work
+    (let c = (the Double-Float (+ (/ 5 2) (* 2 (log 2 (+ 1 (sqrt 2)))))))
+    (let k = (ceiling (+ c (* 2 (log 2 (^^ (into epsilon) -1))))))
+
+    (let next-u =
+      (if (> epsilon (^^ 10 -6))
+          (generate-u-candidate
+           best-approx k
+           (the Double-Float (into epsilon))
+           (the Double-Float (into theta)))
+          #+sbcl
+          (coalton-library/big-float::with-precision precision
+            (fn (_)
+              (generate-u-candidate
+               to-fraction
+               k
+               (the Big-Float (into epsilon))
+               (the Big-Float (into theta)))))
+          #-sbcl
+          (error "Epsilon too small for implmented precision.")))
+    (fn (n)
+      (do
+       (let u = (next-u n))
+       (let xi = (- (^ (the (Root2plex Integer) 2) k) (square-norm u)))
+        ;; (* √2^(-n))
+        (let factor = (times-root2^^ (negate k)))
+
+        (t <- (maybe-find-t-candidate 2 (+ 2 attempts) xi))
+        ;; ξ = (tt^†)
+        (if (== (cyclotomic8-square-modulus t) xi)
+            (progn
+              ;; u-hat = (* u √2^(-n))
+              (let u-hat =
+                (factor
+                 (the (Cyclotomic8 Dyadic)
+                      (map fromInt
+                           (the (Cyclotomic8 Integer) (into u))))))
+              ;; t-hat = (* t √2^(-n))
+              (let t-hat = (factor
+                            (the (Cyclotomic8 Dyadic) (map fromInt t))))
+              (match (sunitary2 u-hat t-hat)
+                ((Some s)
+                 (when (lisp Boolean () (to-boolean cl-quil.frontend:*compiler-noise*))
+                   (print-operator-norm precision s epsilon theta))
+                 (Some s))
+                ((None) None)))
+            None))))
+
+  (declare generate-solution
+           ((Rational :a) (Elementary :a)
+            (Into :a Double-Float) #+sbcl (Into :a Big-float)
+            => (Integer -> :a -> :a
+                        -> (Optional (SUnitary2 (Cyclotomic8 Dyadic))))))
+  (define (generate-solution attempts epsilon theta)
+    "Given THETA which represents an angle of a R_z(θ) gate, return an
+ɛ-approximate U where ‖ U − R_z(θ) ‖ ≤ EPSILON and U ∈ SU(2). There is a
+theoretical chance of failure, but increasing ATTEMPTS or reducing EPSILON will
+increase odds of success. ATTEMPTS is how many times to check the converse of
+the square root of Fermat's Little Theorem (see `prime-mod-solution')
+(ATTEMPTS will work well with the values 1, 2, or 3). Corresponds to the first
+half of Algorithm 23 (arXiv:1212.6253v2)."
+
+    (let n-max = (floor (/ (* 4 (sqrt 2)) epsilon)))
+    (let search =
+      (find-some-until
+       (fn (n) (>= n-max n))
+       (+ 1)
+       (find-candidate attempts epsilon theta)))
+    (search 1))
+
+  (declare generate-maform-output
+           ((Rational :a) (Reciprocable :a)
+            (Into :a Double-Float) #+sbcl (Into :a Big-float)
+            => (Integer -> :a -> :a -> Integer -> (Optional MAForm))))
+  (define (generate-maform-output attempts epsilon theta)
+    "Facilitates `find-candidate' with various attempts at seeded values."
+    (fn (n)
+      (map
+       (fn (x)
+         (the MAForm
+              (into
+               (omega-unitary->ht-sequence
+                (into x)))))
+       (find-candidate attempts epsilon theta n))))
+
+  (monomorphize)
+  (declare generate-maform-output-with-double
+           (Integer -> Integer -> Double-Float -> Double-float -> (Optional (List OutputGate1))))
+  (define (generate-maform-output-with-double candidate-attempts prime-attempts epsilon theta)
+    "If sucessful returns a list of H, S, and T gate in MAForm. It try
+CANDIDATE-ATTEMPTS number of times, and will use PRIME-ATTEMPTS to determine
+how many prime checks to run on an individual candidate before moving onto the next.
+See `generate-solution' for information about EPSILON and THETA."
+    ;; Memoizing on solutions can greatly speed up QUILC compilations
+    ;; when it repeatidly queries for the same simplification
+    (let candidates = (floor (/ (* 4 (sqrt 2)) epsilon)))
+
+    ;; List of functions for finding candidates - this precomputes some values
+    (let candidate-finders =
+      (map
+       (fn (seed)
+         (cond
+           ((== seed 0) (generate-maform-output prime-attempts epsilon theta))
+           ;; At 10^-15 this trick introduces errors due to the precision of pi
+           ((and (< seed 8) (> epsilon (^^ 10 -15)))
+            ;; T^n Rz(theta - m/4 pi)
+            (let f = (generate-maform-output
+                      prime-attempts epsilon
+                      (- theta (* pi (general/ seed 4)))))
+            (fn (n)
+              (@ (Some (into (make-list (HT-T^^ seed))))
+                 (f n))))
+           (True
+            ;; Rz(beta) Rz(theta - beta)
+            (let beta = (psuedo-random seed))
+            ;; We need to convert to fractions for higher precision
+            (let f = (generate-maform-output
+                      prime-attempts  (/ (to-fraction epsilon) 2) beta))
+            (let g = (generate-maform-output
+                      prime-attempts (/ (to-fraction epsilon) 2)
+                      (- (to-fraction theta) beta)))
+            (fn (n) (@ (f n) (g n))))))
+       (range 0 candidate-attempts)))
+    ;; For n, go through each candidate-finder once then proceed to n+1
+    ;; Stop on a solution
+    (let ((rec (fn (finders n)
+                 (match finders
+                   ((Cons f fs)
+                    (match (f n)
+                      ((Some a) (Some a))
+                      ((None) (rec fs n))))
+                   ((Nil)
+                    (if (< n candidates)
+                        (rec candidate-finders (+ n 1))
+                        None))))))
+      (map into (rec candidate-finders 1))))
+
+  (monomorphize)
+  (declare output-T^ (Integer -> (List OutputGate1)))
+  (define (output-T^ n)
+    "Give a list of gates equal to T^n"
+    (operators::universal1->outputgate1 (into (HT-T^^ n))))
+
+  #+sbcl
+  (declare output-distance-rz (Big-Float -> (List OutputGate1) -> Big-Float))
+  (define (output-distance-rz theta ma)
+    (let m1 = ((the ((Rz :a) -> (Mat2 (Complex :a))) into) (Rz theta)))
+    (let m2 = (the (Mat2 (Cyclotomic8 Dyadic))
+                   (into
+                    (the (Unitary2 RootUnity8 (Cyclotomic8 Dyadic))
+                         (into
+                          (the MAForm
+                               (into
+                                (the (List Universal1)
+                                     (map into ma)))))))))
+    (same-type theta
+               (global-phase-invariant-distance
+                m1 (map cyclotomic8->complex m2)))))

--- a/tests/discrete/compilation-tests.lisp
+++ b/tests/discrete/compilation-tests.lisp
@@ -1,0 +1,23 @@
+;;;; src/discrete/parse-tests.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(in-package #:cl-quil.discrete-tests)
+
+(deftest parse-tolerance ()
+  (cl-quil:parse-quil "PRAGMA TOLERANCE \"0.1234\"")
+  (is (<= (- cl-quil.discrete::*tolerance* 0.1234) 1d-16))
+  (cl-quil:parse-quil "PRAGMA TOLERANCE \"2.0e-2\"")
+  (is (<= (- cl-quil.discrete::*tolerance* 2.0d-2) 1d-16))
+  (signals type-error
+    (cl-quil:parse-quil "PRAGMA TOLERANCE \"0\""))
+  (signals type-error
+    (cl-quil:parse-quil "PRAGMA TOLERANCE \"1\"")))
+
+(deftest compile-rz ()
+  ;; While nothing is done with this result,
+  ;; It at the very least assures it runs without errors.
+  (q::compiler-hook
+   (q:parse-quil "PRAGMA TOLERANCE \"1E-10\"; RZ(pi/3) 0")
+   (cl-quil.discrete:build-discrete-linear-chip
+    1 :compile-fast t)))

--- a/tests/discrete/package.lisp
+++ b/tests/discrete/package.lisp
@@ -1,9 +1,31 @@
 ;;;; tests/discrete/package.lisp
 ;;;;
-;;;; Author: Robert Smith
+;;;; Author: Robert Smith, A.J. Nyquist
 
 (fiasco:define-test-package #:cl-quil.discrete-tests
-  (:use #:cl)
+  (:use #:cl
+        #:cl-quil.discrete
+        )
+  (:local-nicknames
+   (#:q #:cl-quil)
+   )
   ;; suite.lisp
   (:export
    #:run-discrete-tests))
+
+(defpackage #:cl-quil.discrete-coalton-tests
+  (:documentation "Tests for the Coalton componenents of clifford-t approx.")
+  (:use #:coalton
+        #:coalton-prelude
+        #:coalton-testing
+        #:coalton-library/math
+        #:cl-quil.discrete/numeric
+        #:cl-quil.discrete/operators
+        #:cl-quil.discrete/rz-approx
+        )
+  (:local-nicknames
+   (#:list #:coalton-library/list)
+   (#:numeric #:cl-quil.discrete/numeric)
+   (#:operator #:cl-quil.discrete/operators)
+   (#:rz #:cl-quil.discrete/rz-approx)
+   ))

--- a/tests/discrete/rz-approx-tests.lisp
+++ b/tests/discrete/rz-approx-tests.lisp
@@ -1,0 +1,291 @@
+;;;; tests/discrete/rz-approx-tests.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(cl:in-package #:cl-quil.discrete-coalton-tests)
+
+;;; Tests solver found in src/discrete/rz-approx/
+
+(coalton-toplevel
+
+  (define (test-interval-solution x-set y-set)
+    (let solution =
+      (rz::interval-solution x-set y-set))
+    (let solution-commute =
+      (rz::interval-solution y-set x-set))
+
+    (is (interval-elem (map fromInt solution) x-set))
+
+    (is (interval-elem (map fromInt solution-commute) y-set))
+
+    (is (interval-elem (map fromInt (root2-conjugate solution)) y-set))
+    (is (interval-elem (map fromInt (root2-conjugate solution-commute)) x-set)))
+
+  (define (test-rescaled-solution x-set y-set)
+    (let delta-x = (interval-distance x-set))
+    (let delta-y = (interval-distance y-set))
+    (is (>= (* delta-x delta-y) (* 2 (^ (Root2plex 1 1) 2))))
+
+    (let odd-solution =
+      (rz::rescaled-interval-solution True x-set y-set))
+    (let even-solution =
+      (rz::rescaled-interval-solution False x-set y-set))
+
+    (is (odd? (root2-real-part odd-solution)))
+    (is (even? (root2-real-part even-solution)))
+
+    (is (interval-elem (map fromInt odd-solution) x-set))
+    (is (interval-elem (map fromInt even-solution) x-set))
+
+    (is (interval-elem (map fromInt (root2-conjugate even-solution)) y-set))
+    (is (interval-elem (map fromInt (root2-conjugate odd-solution)) y-set))))
+
+(define-test rescaled-interval-solution ()
+  (let xy = (the (Root2plex Fraction)
+                 (* 2 (Root2plex 1 1))))
+  (let xy-set = (Interval 0 xy))
+  (test-rescaled-solution xy-set xy-set)
+  (test-interval-solution (Interval 0 (* (^ 10 9) xy)) (Interval (* xy (^^ -10 -9)) 0))
+  (test-rescaled-solution (Interval -10 10) (Interval -2 2)))
+
+(define-test interval-solution-in-zroot2 ()
+  (let xy = (the (Root2plex Fraction)
+                 (Root2plex 1 1)))
+  (let zero = (Root2plex 0 (the Fraction 0)))
+  (let root2 = (Root2plex 0 (the Fraction 1)))
+  (let xy-set = (Interval 0 xy))
+  (test-interval-solution xy-set xy-set)
+
+  (test-interval-solution (Interval zero 10) (Interval -20 20))
+  (test-interval-solution (Interval zero 100) (Interval 0 20))
+
+  (test-interval-solution (Interval zero root2)
+                          (Interval zero (+ 1 root2)))
+  (test-interval-solution (Interval zero 1)
+                          (Interval zero (+ 2 root2)))
+  (test-interval-solution (Interval -1 root2)
+                          (Interval (negate root2) zero))
+
+  (test-interval-solution (Interval -11 -10)
+                          (Interval zero (+ 2 root2)))
+  (test-interval-solution (Interval zero root2)
+                          (Interval -1 root2))
+
+  (test-interval-solution (Interval -1 (- (* 10 (^ xy 2)) 1))
+                          (Interval 1 (+ (Root2plex
+                                          (exact/ 1 10) 0) 1)))
+
+  (test-interval-solution (Interval 0 (* (^ 10 200) (^ xy 2)))
+                          (Interval 0 (Root2plex
+                                       (^^ 10 -200) 0)))
+
+  (test-interval-solution (Interval (*. xy (best-approx -2.42))
+                                    (*. root2 (best-approx 2.33)))
+                          (Interval (*. root2 (best-approx -2.2))
+                                    (*. xy (best-approx 2.4)))))
+
+(define-test j-sub-intervals ()
+  (let epsilon = 0.05)
+  (let n-max = (floor (/ (* 4 (sqrt 2)) epsilon)))
+  (let y-interval = (Interval (exact/ 1 4) (exact/ 1 2)))
+  (let c = (/ (interval-distance y-interval) (fromInt n-max)))
+  (is (> (into c) (/ (^ epsilon 2) 8)))
+
+  (let sub-intervals =
+    (map (rz::j-sub-interval (best-approx (/ (^ epsilon 2) 8))
+                             y-interval)
+         (list:range 1 n-max)))
+  (map
+   (fn (interval)
+     (is (and (< (interval-distance interval) c)
+              (> (interval-distance interval) 0))))
+   sub-intervals)
+
+  (is (== n-max (list:length sub-intervals))))
+
+;;; Test candidate generation
+
+(coalton-toplevel
+  (declare valid-k-epsilon
+           ((Elementary :a) (Ord :a) => (Integer -> :a -> Boolean)))
+  (define (valid-k-epsilon k epsilon)
+    ;; C = 5/2 + 2 log_2 (1 + √2)
+    (let c = (+ (/ 5  2) (log 2 (+ 1 (sqrt 2)))))
+    ;; k ≥ C + log 2(1/ɛ)
+    (let min-k = (+ c (log 2 (^^ epsilon -1))))
+    ;; Assert (30) δΔ = (1 + √2)² by Lemma 17 and min-k
+    (and (and (> epsilon 0) (<= epsilon (/ 1 2)))
+         (>= (fromInt k) min-k)))
+
+  (declare verify-u-candidate ((Elementary :a) (Rational :a)
+                               => Integer -> :a -> :a
+                               -> (Complex (Root2Plex Integer))
+                               -> Unit))
+  (define (verify-u-candidate k epsilon theta u)
+    "Checks if U is a valid candidate for a given K, EPSILON, and THETA.
+Corresponds to Lemma 21 (Selinger, 2014)."
+    (let alpha = (real-part u))
+    (let beta  = (imag-part u))
+    (let z = (exp (complex 0 (/ theta -2))))
+    (let u-hat = (*. (complex (map (fn (x) (exact/ x 1)) alpha)
+                              (map (fn (x) (exact/ x 1)) beta))
+                     (^^ (the (Root2plex Fraction) root2) (negate k))))
+    (let u-hat-float = (complex
+                        (numeric::rroot2->floating (real-part u-hat))
+                        (numeric::rroot2->floating (imag-part u-hat))))
+    (is (rz::in-ball? (root2-conjugate u-hat) (the (Root2plex Fraction) 1)))
+    (is (rz::in-ball? u-hat (the (Root2plex Fraction) 1)))
+    (is (rz::in-epsilon-region? u-hat-float z epsilon))
+    (is (odd? (+ (root2-real-part alpha)
+                 (root2-real-part beta)))))
+
+  (declare test-generate-u-candidates
+           ((Rational :a) (Elementary :a) =>
+            (:a -> :a -> Unit)))
+  (define (test-generate-u-candidates epsilon theta)
+    (let c = (+ (/ 5 2) (* 2 (log 2 (+ 1 (sqrt 2))))))
+    (let k = (ceiling (+ c (* 2 (log 2 (^^ epsilon -1))))))
+
+    (let epsilon-prime = (best-approx epsilon))
+    (let n-max = (floor (/ (* 4 (sqrt 2)) epsilon)))
+    (is (valid-k-epsilon k epsilon))
+
+    ;; δ = √(2^k) ɛ²/8
+    (let delta-x = (* (^ root2 k)
+                      (Root2plex (/ (^ epsilon-prime 2) 8) 0)))
+    ;; Δ = √(2^(k+1))
+    (let delta-y = (+ (^ root2 (+ k 1))
+                      (* 0 delta-x)))
+
+    (test-interval-solution (Interval 0 delta-x) (Interval 0 delta-y))
+
+    (let candidates =
+      (map (rz::generate-u-candidate best-approx k epsilon theta)
+           (list:range 1 n-max)))
+
+    (map (verify-u-candidate k epsilon theta) candidates)
+    (is (== n-max (list:length candidates)))))
+
+(define-test generate-u-candidates ()
+  (test-generate-u-candidates 0.5 0.0)
+  ;; Works but takes a while, smaller epsilons result in GC error
+  ;; (test-generate-u-candidates 0.0001 0.1)
+  (test-generate-u-candidates 0.01 (* pi 0.25))
+  (test-generate-u-candidates 0.25 (* pi 0.5))
+  (test-generate-u-candidates 0.015 (* pi 1.9))
+  (test-generate-u-candidates 0.5 (* pi 0.9))
+  (test-generate-u-candidates 0.5d0 (* pi 1.0d0))
+  (test-generate-u-candidates 0.5 (* pi 1.1)))
+
+;;; Test candidate verification
+
+(define-test prime-mod-solution ()
+  (is (isSome (rz::prime-mod-solution 2 7 7)))
+  (is (isNone (rz::prime-mod-solution 0 10 10)))
+  (is (isSome (rz::prime-mod-solution 0 100 16843))))
+
+(define-test square-root-of-root2-unit ()
+  (is (== (Some (^ (Root2plex -1 1) 4))
+          (rz::square-root-of-root2-unit (^ (Root2plex -1 1) 8))))
+  (is (== (Some (^ (Root2plex -1 1) 3))
+          (rz::square-root-of-root2-unit (^ (Root2plex -1 1) 6))))
+  (is (/= (Some (^ (Root2plex -2 1) 2))
+          (rz::square-root-of-root2-unit (^ (Root2plex -1 2) 4)))))
+
+;;; Test exact synthesis
+
+(coalton-toplevel
+  (declare ma-normal-form-check
+           ((Unitary2 RootUnity8 (Cyclotomic8 Dyadic)) -> Boolean))
+  (define (ma-normal-form-check unitary)
+    (let maform = (the MAForm (into unitary)))
+    (is (projective-equivalence
+         unitary
+         (foldable->action
+          (the (List OutputGate1) (into maform)))))
+    (== unitary (into maform)))
+
+  (declare hadamardt-synthesis-check ((List HadamardT) -> Boolean))
+  (define (hadamardt-synthesis-check hts)
+    (let unitary = (foldable->action hts))
+    (is (== unitary (foldable->action
+                     (operator::omega-unitary->ht-sequence unitary))))
+    (ma-normal-form-check unitary)))
+
+(define-test exact-synthesis ()
+  (is (hadamardt-synthesis-check (make-list HT-H)))
+  (is (hadamardt-synthesis-check (make-list (HT-T^^ 10))))
+  (is (hadamardt-synthesis-check (map (fn (_) HT-H) (list:range 0 10))))
+  (is (hadamardt-synthesis-check (make-list  (HT-T^^ 3) HT-H)))
+  (is (hadamardt-synthesis-check (make-list HT-H (HT-T^^ 2) HT-H)))
+  (is (hadamardt-synthesis-check
+       (make-list HT-H (HT-T^^ 1) HT-H (HT-T^^ 2)
+                  HT-H (HT-T^^ 3) HT-H (HT-T^^ 4))))
+  (is (hadamardt-synthesis-check (make-list HT-H (HT-T^^ 0))))
+  (is (hadamardt-synthesis-check
+       (make-list HT-H HT-H (HT-T^^ 2) (HT-T^^ 0)))))
+
+;;; Test final candidate result
+
+(coalton-toplevel
+  (define (omega-unitary2->mat2 a)
+    (the (Mat2 (Complex :a))
+         (map numeric::cyclotomic8->complex
+              (the (Mat2 (Cyclotomic8 Dyadic))
+                   (into a)))))
+
+  (define (candidate-check attempts epsilon theta)
+    (match (rz::generate-solution attempts epsilon theta)
+      ((Some a)
+       (and
+        ;; No matter the operator the spectral radius l.e. to the norm
+        (>= epsilon ((the ((Mat2 (Complex :a)) -> :a)
+                          spectral-radius)
+                     (- (omega-unitary2->mat2 a)
+                        (into (Rz theta)))))
+        ;; Check MAForm is equal to original unitary
+        (ma-normal-form-check (into a))))
+      ((None) False))))
+
+(define-test candidate-solver ()
+  ;; Solutions are not gaurenteed - values may need to be adjusted
+  (is (candidate-check 2 0.5d0 1))
+  (is (candidate-check 4 0.02d0 3))
+  (is (candidate-check 4 0.01d0 6))
+  (is (candidate-check 2 (* 1 (pow 10 -4)) (* pi 1.25d0)))
+  (is (candidate-check 2 (* 3 (pow 10 -4)) (* pi 0.3d0)))
+  (is (candidate-check 4 (* 5 (pow 10 -8)) (* pi 0.5d0)))
+  (is (candidate-check 4 0.25d0 (* pi 1.5d0))))
+
+(coalton-toplevel
+  (declare solution-check
+           (Double-Float -> Double-Float -> (List OutputGate1) -> Boolean))
+  (define (solution-check theta epsilon outputgates)
+    (>= epsilon
+        (global-phase-invariant-distance
+         (omega-unitary2->mat2
+          (the (Unitary2 RootUnity8 (Cyclotomic8 Dyadic))
+               (foldable->action outputgates)))
+         (the (Mat2 (Complex Double-Float))
+              (into (Rz theta))))))
+
+  (define (solution-check-float theta epsilon)
+    (solution-check
+     theta epsilon
+     (unwrap
+      (generate-maform-output-with-double
+       25 2 epsilon theta))))
+
+  (define (solution-check-pi n)
+    (solution-check
+     (* (general/ n 4) pi) (^^ 10 -7)
+     (the (List OutputGate1) (output-T^ n)))))
+
+(define-test discretize-rz-helpers ()
+  (map (fn (n) (is (solution-check-pi n)))
+       (range 0 16))
+  (map (fn (n) (is (solution-check-float
+                    (* (* 2 pi) (sin (fromInt n)))
+                    (^^ (fromInt n) -2))))
+       (range 2 30))
+  Unit)

--- a/tests/discrete/suite.lisp
+++ b/tests/discrete/suite.lisp
@@ -22,3 +22,7 @@
                                           :describe-failures t
                                           :interactive nil)))
          (uiop:quit (if successp 0 1)))))))
+
+(in-package #:cl-quil.discrete-coalton-tests)
+
+(coalton-fiasco-init :cl-quil.discrete-tests)

--- a/tests/discrete/tests.lisp
+++ b/tests/discrete/tests.lisp
@@ -1,9 +1,0 @@
-;;;; tests/discrete/tests.lisp
-;;;;
-;;;; Author:
-
-(in-package #:cl-quil.discrete-tests)
-
-(deftest test-math ()
-  (is (= 2 (+ 1 1))))
-


### PR DESCRIPTION
For usage see `src/discrete/README.md`

Implements the following papers:
- Approximation of RZ as unitaries over Z[i,1/sqrt(2)] (arXiv:1212.6253v2)
- Decomposes unitaries representable by Clifford+T (arXiv:1206.5236)
- Outputs as Matsumoto Amano Normal Form (arXiv:1312.6584)

Pending on:
 - https://github.com/coalton-lang/coalton/pull/533
 - (Optional) https://github.com/coalton-lang/coalton/issues/534
 - (Optional) https://github.com/quil-lang/quilc/pull/820 