### PR TITLE
Add tolerance check

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -404,10 +404,16 @@
                ;; can print the input and output unitary matrix as
                ;; comments at the end of the output.
                (when (and protoquil compute-matrix-reps)
-                 (let* ((processed-program-matrix (parsed-program-to-logical-matrix processed-program :compress-qubits t)))
-                   (print-matrix-comparision original-matrix
-                                             (quil::scale-out-matrix-phases processed-program-matrix
-                                                                            original-matrix)))))
+                 (let* ((processed-program-matrix (parsed-program-to-logical-matrix processed-program :compress-qubits t))
+                        ;; If a TOLERANCE pragma is found, allow non-zero phase invariant distance
+                        (tolerance (cl-quil::prog-find-top-pragma program "TOLERANCE")))
+                   (if tolerance
+                       (print-matrix-comparision
+                        original-matrix processed-program-matrix
+                        :tolerance t)
+                       (print-matrix-comparision
+                        original-matrix
+                        (quil::scale-out-matrix-phases processed-program-matrix original-matrix))))))
 
              ;; New and improved flow
              (when compile

--- a/app/src/printers.lisp
+++ b/app/src/printers.lisp
@@ -11,14 +11,23 @@
 (declaim (special *without-pretty-printing*
                   *human-readable-stream*))
 
-(defun print-matrix-comparision (m1 m2 &optional (stream *human-readable-stream*))
+(defun print-matrix-comparision (m1 m2 &key (stream *human-readable-stream*)
+                                         (tolerance nil))
+  "Given to matrices M1 and M2, print to a STREAM their entries and whether they
+are numerically unitary. If TOLERANCE is nil, check if if they are equal and
+error if they are not in the same projective class. If TOLERANCE is t, instead
+print out their `global-phase-invariant-distance' with no error."
   (format stream "~%#Matrix read off from input code (~:[not ~;~]unitary)~%"
           (magicl:unitary-matrix-p m1))
   (print-matrix-with-comment-hashes m1 stream)
   (format stream "~%#Matrix read off from compiled code (~:[not ~;~]unitary)~%"
           (magicl:unitary-matrix-p m2))
   (print-matrix-with-comment-hashes m2 stream)
-  (format stream "~%#Matrices are~:[ not~;~] equal~%" (quil::matrix-equals-dwim m1 m2))
+  (if tolerance
+      (format stream "~%#Matrices have a global phase invariant distance of ~E~%"
+              (cl-quil::global-phase-invariant-distance m1 m2))
+      (format stream "~%#Matrices are~:[ not~;~] equal~%"
+              (quil::matrix-equals-dwim m1 m2)))
   (finish-output stream))
 
 (defun print-program (processed-program &optional (stream *standard-output*))

--- a/src/addresser/initial-rewiring.lisp
+++ b/src/addresser/initial-rewiring.lisp
@@ -114,13 +114,9 @@ If no
     PRAGMA INITIAL_REWIRING \"...\"
 
 is found, then return NIL."
-  (loop :for inst :across (parsed-program-executable-code parsed-prog) :do
-    (cond
-      ((typep inst 'pragma)
-       (when (typep inst 'pragma-initial-rewiring)
-         (return-from prog-rewiring-pragma (pragma-rewiring-type inst))))
-      (t
-       (return-from prog-rewiring-pragma nil)))))
+
+  (a:when-let ((pragma (prog-find-top-pragma parsed-prog 'pragma-initial-rewiring)))
+    (pragma-rewiring-type pragma)))
 
 (defun %naively-applicable-p (instr chip-spec
                               &aux (qubit-indices (qubits-used instr)))

--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -337,3 +337,11 @@ as matrices."
   "Treats m in SU(2) as either m (x) Id or Id (x) m."
   (kq-gate-on-lines m 2 (list line)))
 
+(defun global-phase-invariant-distance (m1 m2)
+  "Measures the 'distance' between two unitary matrices up to a global phase
+(see arXiv:2106.07099). Returns D = sqrt(1-|tr(M1 M2^-1)|/n) where 0<=D<=1 and
+M1 and M2 are n x n."
+  (assert (= (magicl:nrows m1) (magicl:ncols m1)
+             (magicl:nrows m2) (magicl:ncols m2)))
+  (sqrt (- 1 (/ (abs (magicl:trace (magicl:@ m1 (magicl:dagger m2))))
+                (magicl:nrows m1)))))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -93,3 +93,16 @@ appropriate method of comparison."
   (calculate-instructions-fidelity
    (coerce (parsed-program-executable-code program) 'list)
    chip))
+
+(defun prog-find-top-pragma (parsed-prog pragma)
+  "Finds and returns the first PRAGMA in the PARSED-PROG. PRAGMA may either be a
+symbol of representing the type, or a string equal representing a pragma word.
+This pragma needs to occur before any non-pragma instructions. If no pragma is
+found, then return NIL."
+  (loop :for inst :across (parsed-program-executable-code parsed-prog) :do
+    (if (typep inst 'pragma)
+        (when (or (and (symbolp pragma) (typep inst pragma))
+                  (and (stringp pragma)
+                       (member pragma (pragma-words inst) :test #'equal)))
+          (return-from prog-find-top-pragma inst))
+        (return-from prog-find-top-pragma nil))))


### PR DESCRIPTION
Description:
When using a tolerance pragma (e.g. `PRAGMA TOLERANCE "0.5"`), print global phase invariant distance ([arXiv:2106.07099](https://arxiv.org/abs/2106.07099)) instead of erroring when matrices are inevitably in the wrong projective class (e.g. `#Matrices have a phase invariant distance of 0.29746263355117152d0`).

Changes:
  - If tolerance pragma, prevent matrix scaling error
  - Make function for checking top pragmas