### PR TITLE
Add a new chip library system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,11 @@ test-libquilc:
 		--eval "(ql:quickload :libquilc-tests)" \
 		--eval "(asdf:test-system :libquilc)"
 
+test-chip-library:
+	$(QUICKLISP) \
+		--eval "(ql:quickload :cl-quil/chip-library-tests)" \
+		--eval "(asdf:test-system :cl-quil/chip-library)"
+
 test-quilt:
 	$(QUICKLISP) \
 		--eval "(ql:quickload :cl-quil/quilt-tests)" \

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -30,16 +30,10 @@
            (coerce #(#\Newline #\#) 'string))))
 
 (defun lookup-isa-descriptor-for-name (isa)
-  (a:switch (isa :test #'string=)
-    ("8Q" (quil::build-8Q-chip))
-    ("20Q" (quil::build-skew-rectangular-chip 0 4 5))
-    ("16QMUX" (quil::build-16QMUX-chip))
-    ("bristlecone" (quil::build-bristlecone-chip))
-    ("ibmqx5" (quil::build-ibm-qx5))
-    (t
-     (if (probe-file isa)
-         (quil::read-chip-spec-file isa)
-         (error "ISA descriptor does not name a known template or an extant file.")))))
+  (or (call-chip-builder isa)
+      (if (probe-file isa)
+          (quil::read-chip-spec-file isa)
+          (error "ISA descriptor does not name a known template or an extant file."))))
 
 (defun log-level-string-to-symbol (log-level)
   (a:eswitch (log-level :test #'string=)
@@ -90,6 +84,10 @@
 (defun show-backends ()
   (format t "Available backends:~%")
   (format t "~{  ~(~A~)~^~%~}~%" (mapcar #'quil:backend-name (quil:list-available-backends))))
+
+(defun show-chips ()
+  (format t "Available ISAs:~%")
+  (format t "~{  ~(~A~)~^~%~}~%" (cl-quil.chip-library:available-chips)))
 
 (defun check-libraries ()
   "Check that the foreign libraries are adequate. Exits with status
@@ -197,6 +195,7 @@
                           (backend nil)
                           (backend-option nil)
                           (list-backends nil)
+                          (list-chips nil)
                           (output nil)
 
                           (enable-state-prep-reductions nil)
@@ -241,6 +240,10 @@
 
   (when list-backends
     (show-backends)
+    (uiop:quit 0))
+
+  (when list-chips
+    (show-chips)
     (uiop:quit 0))
 
   (when check-libraries

--- a/app/src/options.lisp
+++ b/app/src/options.lisp
@@ -41,7 +41,13 @@
      :type string
      :optional t
      :initial-value "8Q"
-     :documentation "set ISA to one of \"8Q\", \"20Q\", \"16QMUX\", \"bristlecone\", \"ibmqx5\", or path to QPU description file")
+     :documentation "set to an available ISA (see --list-chips) or path to QPU description file")
+
+    (("list-chips")
+     :type boolean
+     :optional t
+     :initial-value nil
+     :documentation "list available ISA that can be passed to --isa")
 
     (("compile" #\c)
      :type boolean

--- a/app/src/package.lisp
+++ b/app/src/package.lisp
@@ -5,5 +5,5 @@
 (in-package #:cl-user)
 
 (defpackage #:quilc
-  (:use #:cl #:cl-quil)
+  (:use #:cl #:cl-quil #:cl-quil.chip-library)
   (:local-nicknames (:a :alexandria)))

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -170,6 +170,34 @@
                              (:file "simplification-grab-bag")))
                (:file "initialize-standard-gates")))
 
+(asdf:defsystem #:cl-quil/chip-library
+  :description "Holds definitions for various chip ISAs."
+  :license "Apache License 2.0 (See LICENSE.txt)"
+  :depends-on (#:cl-quil)
+  :in-order-to ((asdf:test-op (asdf:test-op #:cl-quil/chip-library-tests)))
+  :around-compile (lambda (compile)
+                    (let (#+sbcl (sb-ext:*derive-function-types* t))
+                      (funcall compile)))
+  :pathname "src/chip-library/"
+  :serial t
+  :components ((:file "package")
+               (:file "chip-table")))
+
+(asdf:defsystem #:cl-quil/chip-library-tests
+  :description "Test suite for cl-quil/chip-library."
+  :license "Apache License 2.0 (See LICENSE.txt)"
+  :depends-on (#:cl-quil
+               #:cl-quil/chip-library
+               #:fiasco)
+  :perform (asdf:test-op (o s)
+                         (uiop:symbol-call ':cl-quil.chip-library-tests
+                                           '#:run-chip-library-tests))
+  :pathname "tests/chip-library/"
+  :serial t
+  :components ((:file "package")
+               (:file "suite")
+               (:file "chip-table-tests")))
+
 ;;; Contribs
 
 ;; Adapted from magicl's MAGICL/EXT-EXPOKIT adapted from commonqt's

--- a/quilc.asd
+++ b/quilc.asd
@@ -15,6 +15,7 @@
                (:version #:magicl/core "0.9.0")
                #:magicl/ext-lapack
                #:cl-quil
+               #:cl-quil/chip-library
                #:cl-quil-benchmarking
                #:uiop
                #:bordeaux-threads

--- a/src/chip-library/chip-table.lisp
+++ b/src/chip-library/chip-table.lisp
@@ -1,0 +1,43 @@
+;;;; src/chip-library/chip-table.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(in-package cl-quil.chip-library)
+
+;;; Mutable table that stores functions for defining chips
+
+(defvar *chip-table*
+  (make-hash-table :test 'equalp)
+  "Table that match hashed keywords to functions that build chips.")
+
+(defun available-chips ()
+  "Returns a list of chip builder string-keys available."
+  (a:hash-table-keys *chip-table*))
+
+(defun get-chip-builder (chip)
+  "Returns a chip building function with the case-insensitive string-key CHIP."
+  (declare (type string chip))
+  (nth-value 0 (gethash chip *chip-table*)))
+
+(defun install-chip-builder (chip func &key (no-warn nil))
+  "Stores the chip building function FUNC with the string-key CHIP, if CHIP is
+already utilized return t and unless NO-WARN signal a warning."
+  (declare (type string chip))
+  (when (shiftf (gethash chip *chip-table*) func)
+    (unless no-warn
+      (a:simple-style-warning "Overwriting existing chip ~A" chip))
+    t))
+
+(defun call-chip-builder (chip &rest args)
+  "Calls the chip building function associated with CHIP while passing ARGS, or
+returns nil if not found."
+  (a:when-let ((chip-builder (get-chip-builder chip)))
+    (apply chip-builder args)))
+
+;; Install default chips
+
+(install-chip-builder "8Q" 'q::build-8Q-chip)
+(install-chip-builder "20Q" (lambda () (q::build-skew-rectangular-chip 0 4 5)))
+(install-chip-builder "16QMUX" 'q::build-16QMUX-chip)
+(install-chip-builder "bristlecone" 'q::build-bristlecone-chip)
+(install-chip-builder "ibmqx5" 'q::build-ibm-qx5)

--- a/src/chip-library/package.lisp
+++ b/src/chip-library/package.lisp
@@ -1,0 +1,14 @@
+;;;; src/chip-library/package.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(defpackage #:cl-quil.chip-library
+  (:use #:cl)
+  (:local-nicknames (:q :cl-quil)
+                    (:a :alexandria))
+  (:export
+   #:available-chips                    ; FUNCTION
+   #:install-chip-builder               ; FUNCTION
+   #:get-chip-builder                   ; FUNCTION
+   #:call-chip-builder                  ; FUNCTION
+   ))

--- a/tests/chip-library/chip-table-tests.lisp
+++ b/tests/chip-library/chip-table-tests.lisp
@@ -1,0 +1,18 @@
+;;;; tests/chip-library/chip-table-tests.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(in-package #:cl-quil.chip-library-tests)
+
+(deftest default-chips ()
+  (is (equalp (call-chip-builder "8q") (q::build-8q-chip)))
+  (is (equalp (call-chip-builder "20Q") (q::build-skew-rectangular-chip 0 4 5))))
+
+(deftest define-chip ()
+  ;; Uses the non-sense name ""
+  (install-chip-builder "" nil :no-warn t)
+  (is (not (install-chip-builder "" #'q::build-skew-rectangular-chip)))
+  (is (equalp (q::build-skew-rectangular-chip 0 1 2)
+              (call-chip-builder "" 0 1 2)))
+  (is (install-chip-builder "" nil :no-warn t))
+  (is (not (install-chip-builder "" nil))))

--- a/tests/chip-library/package.lisp
+++ b/tests/chip-library/package.lisp
@@ -1,0 +1,10 @@
+;;;; tests/chip-library/package.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(fiasco:define-test-package #:cl-quil.chip-library-tests
+  (:use #:cl #:cl-quil.chip-library)
+  (:local-nicknames (:q :cl-quil))
+  ;; suite.lisp
+  (:export
+   #:run-chip-library-tests))

--- a/tests/chip-library/suite.lisp
+++ b/tests/chip-library/suite.lisp
@@ -1,0 +1,24 @@
+;;;; tests/chip-library/suite.lisp
+;;;;
+;;;; Author: A.J. Nyquist
+
+(in-package #:cl-quil.chip-library-tests)
+
+(defun run-chip-library-tests (&key (verbose nil) (headless nil))
+  "Run all CL-QUIL/CHIP-LIBRARY tests. If VERBOSE is T, print out lots of test info. If HEADLESS is T, disable interactive debugging and quit on completion."
+  ;; Bug in Fiasco commit fe89c0e924c22c667cc11c6fc6e79419fc7c1a8b
+  (let ((fiasco::*test-run-standard-output* (make-broadcast-stream
+                                             *standard-output*))
+        (quil::*compress-carefully* t))
+    (cond
+      ((null headless)
+       (run-package-tests :package ':cl-quil.chip-library-tests
+                          :verbose verbose
+                          :describe-failures t
+                          :interactive t))
+      (t
+       (let ((successp (run-package-tests :package ':cl-quil.chip-library-tests
+                                          :verbose t
+                                          :describe-failures t
+                                          :interactive nil)))
+         (uiop:quit (if successp 0 1)))))))


### PR DESCRIPTION
Defines a system for post-loading new arguments to `quilc --isa ...`.

Right now this is a separate system for two reasons:
- It keeps mutation out of `cl-quil`
- It isolates the development/archival of ISAs to a separate location

Semi-relevant issue:  #818