### PR TITLE
Install additional dependencies in Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ workflow:
     - linux
   before_script:
     - apt update
-    - apt install -y --no-install-recommends ca-certificates git sbcl make curl gcc pkg-config liblapack-dev libblas-dev libgfortran5 gfortran libffi-dev
+    - apt install -y --no-install-recommends ca-certificates git sbcl make curl gcc pkg-config liblapack-dev libblas-dev libgfortran5 gfortran libffi-dev libffi7 libssl-dev
     - echo "$QUILC_CA_BUNDLE" > /usr/local/share/ca-certificates/my-ca.crt && update-ca-certificates
     - mkdir -p ${HOME}/quicklisp/local-projects
     - git -C ${HOME}/quicklisp/local-projects clone https://github.com/quil-lang/magicl.git


### PR DESCRIPTION
The Gitlab CI pipeline was failing to load libcrypto (libssl-dev seemed not to be installed) and libffi (wanted an old version). With a little luck, this change installs them in the CI runner.

Note that this PR does not change Github actions; I'm not sure if those are broken or not.