### PR TITLE
`copy-instance` kwargs to overwrite slots

### DIFF
--- a/src/frontend-utilities.lisp
+++ b/src/frontend-utilities.lisp
@@ -5,18 +5,18 @@
 
 (in-package #:cl-quil.frontend)
 
-(defgeneric copy-instance (instance)
+(defgeneric copy-instance (instance &key &allow-other-keys)
   (:documentation
    "Create a shallow copy of the object INSTANCE.
 WARNING: The default will work for instances of \"idiomatic\" classes that aren't doing too many crazy things.")
-  (:method ((instance t))
+  (:method ((instance t) &rest slot-overwrites &key &allow-other-keys)
     (let* ((class (class-of instance))
            (copy (allocate-instance class)))
       (dolist (slot (mapcar #'closer-mop:slot-definition-name (closer-mop:class-slots class)))
         (when (slot-boundp instance slot)
           (setf (slot-value copy slot)
                 (slot-value instance slot))))
-      copy)))
+      (apply #'reinitialize-instance copy slot-overwrites ))))
 
 (defmacro dohash (((key val) hash &optional ret) &body body)
   `(loop :for ,key :being :the :hash-keys :of ,hash


### PR DESCRIPTION
You can now do e.g. `(copy-instance SOME-BINARY-CLASSICAL-INSTRUCTION :left
NEW-LEFT-OPERAND)` to make a copy of `SOME-BINARY-CLASSICAL-INSTRUCTION` that has its
`left` slot overwritten with `NEW-LEFT-OPERAND`. I suspect there are plenty of places in
the QuilC code where this would enable a much nicer functional style by eliminating
patterns like `(let ((copy (copy-instance FOO))) (setf (FOO-BAR FOO) BAR))`.