### PR TITLE
A couple of libquilc fixes

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,7 +3,7 @@
 all: libquilc.dylib
 
 libquilc.core libquilc.c libquilc.h libquilc.py: src/libquilc.lisp
-	sbcl --load "$<"
+	sbcl --dynamic-space-size 4096 --load "src/build-image.lisp"
 
 libquilc.dylib: libquilc.core libquilc.c
 	gcc -dynamiclib -o $@ libquilc.c -lsbcl

--- a/lib/src/libquilc.lisp
+++ b/lib/src/libquilc.lisp
@@ -20,11 +20,11 @@
   (:type quil-program chip-specification error-type)
   (:literal "/* functions */")
   (:function
-   (("parse_quil" quil:safely-parse-quil) quil-program ((source :string)))
-   (("print_program" quilc::print-program) :void ((program quil-program)))
-   (("compile_quil" quil:compiler-hook) quil-program ((program quil-program) (chip-spec chip-specification)))
+   (("parse_quil" cl-quil.frontend:safely-parse-quil) quil-program ((source :string)))
+   (("print_program" cl-quil.frontend:print-parsed-program) :void ((program quil-program)))
+   (("compile_quil" cl-quil:compiler-hook) quil-program ((program quil-program) (chip-spec chip-specification)))
    (("compile_protoquil" compile-protoquil) quil-program ((program quil-program) (chip-spec chip-specification)))
-   (("build_nq_linear_chip" quil::build-nq-linear-chip) chip-specification ((n :int)))
+   (("build_nq_linear_chip" cl-quil::build-nq-linear-chip) chip-specification ((n :int)))
    (("chip_spec_from_isa_descriptor" quilc::lookup-isa-descriptor-for-name) chip-specification ((descriptor :string)))
-   (("print_chip_spec" quil::debug-print-chip-spec) :void ((chip-spec chip-specification)))))
+   (("print_chip_spec" cl-quil::debug-print-chip-spec) :void ((chip-spec chip-specification)))))
 

--- a/lib/tests/c/Makefile
+++ b/lib/tests/c/Makefile
@@ -3,7 +3,7 @@ BUILD_DIR = ../..
 CCFLAGS = -lsbcl -lquilc -L$(BUILD_DIR) -I$(BUILD_DIR)
 
 OS:=$(shell uname -s)
-ifeq ($(UNAME_S), Darwin)
+ifeq ($(OS), Darwin)
 	CCFLAGS += -pagezero_size 0x100000
 endif
 


### PR DESCRIPTION
This PR does two things:

- Use the `cl-quil` and `cl-quil.frontend` packages instead of `quil` when exporting functions in `libquilc.lisp`
- Fix an incorrect variable name in the Makefile for the libquilc C tests so that the `-pagezero_size 0x100000` flag gets passed on macOS