### PR TITLE
Increase heap size when initializing runtime for libquilc

### DIFF
--- a/lib/src/build-image.lisp
+++ b/lib/src/build-image.lisp
@@ -8,6 +8,6 @@
 (sbcl-librarian:define-aggregate-library libquilc (:function-linkage "QUILC_API")
   quilc sbcl-librarian:handles)
 
-(sbcl-librarian:build-bindings libquilc ".")
+(sbcl-librarian:build-bindings libquilc "." :initialize-lisp-args '("--dynamic-space-size" "8192"))
 (sbcl-librarian:build-python-bindings libquilc ".")
 (sbcl-librarian:build-core-and-die libquilc ".")


### PR DESCRIPTION
## Notes
This PR uses the `initialize-lisp-args` option introduced by quil-lang/sbcl-librarian#36 to increase the default heap size to 8 GiB when initializing the runtime in the bindings for libquilc.

## Testing
Built libquilc against SBCL master with the bigger heap size on macOS, the `compile-quil` C test now runs without issue.