### PR TITLE
check for diagonal matrices in find-diag-in-e-basis

### DIFF
--- a/src/matrix-operations.lisp
+++ b/src/matrix-operations.lisp
@@ -8,6 +8,13 @@
 
 (in-package #:cl-quil)
 
+(defun diagonal-matrix-p (m)
+  "Is M diagonal?"
+  (dotimes (row (magicl:nrows m) t)
+    (dotimes (col (magicl:ncols m))
+      (when (and (/= row col) (not (double~ 0 (magicl:tref m row col))))
+        (return-from diagonal-matrix-p nil)))))
+
 (defun matrix-first-column-equality (x y)
   (check-type x magicl:matrix)
   (check-type y magicl:matrix)


### PR DESCRIPTION
It seems that LAPACK becomes unstable on ARM when attempting to find the eigenvectors and eigenvalues of a diagonal matrix. This instability is triggered in find-diagonalizer-in-e-basis. The operation becomes trivial when run on a diagonal matrix, so we check for this and return the identity to avoid making a potentially unstable LAPACK call.

Fixes #842.