### PR TITLE
abstract out stdgates.quil path to *default-standard-gates-file*

### DIFF
--- a/src/frontend-options.lisp
+++ b/src/frontend-options.lisp
@@ -29,3 +29,8 @@ N.B., The fractions of pi will be printed up to a certain precision!")
 
 (defvar *print-polar-form* nil
   "When true, FORMAT-COMPLEX prints out complex numbers in polar form with syntax AMPLITUDE∠PHASE.")
+
+(defvar *default-standard-gates-file*
+  (or (uiop:getenv "QUILC_STANDARD_GATES_FILE")
+      (asdf:system-relative-pathname "cl-quil" "src/quil/stdgates.quil"))
+  "The default location of the \"stdgates.quil\" file. The environment variable QUILC_STANDARD_GATES_FILE will be checked first, otherwise the path into this project's source code will be used.")

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -37,6 +37,7 @@
    #:*print-fractional-radians*         ; VARIABLE
    #:*print-polar-form*                 ; VARIABLE
    #:*compiler-noise*                   ; VARIABLE
+   #:*default-standard-gates-file*      ; VARIABLE
    )
 
   ;; types.lisp
@@ -535,6 +536,11 @@
    #:*safe-include-directory*           ; VARIABLE
 
    #:ambiguous-definition-condition     ; CONDITION
+   )
+
+  ;; initialize-standard-gates.lisp
+  (:export
+   #:initialize-standard-gates          ; FUNCTION
    )
 
   ;; gates.lisp


### PR DESCRIPTION
Instead of inlined calls to `asdf:system-relative-pathname`, instead we offer a new exported variable `*default-standard-gates-file*`