### PR TITLE
Feature/simplify dockerfile

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,21 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build the Image
+        run: |
+          docker buildx build \
+          --tag rigetti/quilc:latest \
+          --platform linux/amd64,linux/arm/v7,linux/arm64 . 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,51 @@
-# specify the dependency versions (can be overriden with --build_arg)
-ARG rpcq_version=3.2.0
-ARG qvm_version=1.17.0
-ARG quicklisp_version=2021-04-11
+FROM ubuntu:20.04
 
-# use multi-stage builds to independently pull dependency versions
-FROM rigetti/rpcq:$rpcq_version as rpcq
-FROM rigetti/qvm:$qvm_version as qvm
-FROM rigetti/lisp:$quicklisp_version
+# Build variables
+ARG QUICKLISP_VERSION=2022-04-01
+ARG QUICKLISP_URL=http://beta.quicklisp.org/dist/quicklisp/${QUICKLISP_VERSION}/distinfo.txt
 
-# copy over rpcq source from the first build stage
-COPY --from=rpcq /src/rpcq /src/rpcq
+# Dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y \
+    emacs \
+    curl \
+    wget \
+    git \
+    build-essential \
+    cmake \
+    libblas-dev \
+    libffi-dev \
+    liblapack-dev \
+    libz-dev \
+    libzmq3-dev \
+    rlwrap \
+    sbcl \
+    gfortran \
+    ca-certificates
 
-# copy over qvm source from the second build stage (needed for unit tests)
-COPY --from=qvm /src/qvm /src/qvm
+WORKDIR /usr/src
 
-ARG build_target
+# Quicklisp setup
+RUN wget -P /tmp/ 'https://beta.quicklisp.org/quicklisp.lisp' \
+    && sbcl --noinform --non-interactive --load /tmp/quicklisp.lisp \
+            --eval "(quicklisp-quickstart:install :dist-url \"${QUICKLISP_URL}\")" \
+    && sbcl --noinform --non-interactive --load ~/quicklisp/setup.lisp \
+            --eval '(ql-util:without-prompting (ql:add-to-init-file))' \
+    && echo '#+quicklisp(push (truename "/usr/src") ql:*local-project-directories*)' >> ~/.sbclrc \
+    && rm -f /tmp/quicklisp.lisp
 
-# install build dependencies
-COPY Makefile /src/quilc/Makefile
-WORKDIR /src/quilc
+# Get the latest versions of QVM and Magicl
+RUN git clone https://github.com/quil-lang/qvm.git
+RUN git clone https://github.com/quil-lang/magicl.git
+
+# Copy the source code
+RUN mkdir /usr/src/quilc
+WORKDIR /usr/src/quilc
+COPY . .
 RUN make dump-version-info install-test-deps
 
-# build the quilc app
-ADD . /src/quilc
-WORKDIR /src/quilc
+# Build
 RUN git clean -fdx && make ${build_target} install && ldconfig
 
 EXPOSE 5555

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as dev
 
 # Build variables
 ARG QUICKLISP_VERSION=2022-04-01
@@ -42,6 +42,9 @@ RUN git clone https://github.com/quil-lang/magicl.git
 # Copy the source code
 RUN mkdir /usr/src/quilc
 WORKDIR /usr/src/quilc
+
+FROM dev as app
+
 COPY . .
 RUN make dump-version-info install-test-deps
 

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,10 @@ docker-sdk-barebones: DOCKER_BUILD_TARGET=quilc-sdk-barebones
 docker-sdk-barebones: DOCKER_TAG=quilc-sdk-barebones
 docker-sdk-barebones: docker
 
+# Start a dockerized sbcl for development
+docker-sbcl:
+	docker compose up
+
 ###############################################################################
 # INSTALL/UNINSTALL
 ###############################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.5'
+
+# TODO: non-root user
+
+# docker run -it --rm --name sbcl-slime
+# -p 127.0.0.1:4005:4005
+# -v /path/to/slime:/usr/src/slime
+# -v "$PWD":/usr/src/app
+# -w /usr/src/app
+# daewok/sbcl:latest
+# sbcl --load /usr/src/slime/swank-loader.lisp
+# --eval '(swank-loader:init)'
+# --eval '(swank:create-server :dont-close t :interface "0.0.0.0")'
+
+services:
+  sbcl:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        UID: 1000
+        GID: 1000
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/usr/src/quilc
+      - ~/.emacs.d/elpa/slime-20221003.936/:/usr/src/slime/
+    ports:
+      - 4005:4005
+    command: sbcl --load /usr/src/slime/swank-loader.lisp --eval '(swank-loader:init)' --eval '(swank:create-server :dont-close t :interface "0.0.0.0")'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,6 @@ version: '3.5'
 
 # TODO: non-root user
 
-# docker run -it --rm --name sbcl-slime
-# -p 127.0.0.1:4005:4005
-# -v /path/to/slime:/usr/src/slime
-# -v "$PWD":/usr/src/app
-# -w /usr/src/app
-# daewok/sbcl:latest
-# sbcl --load /usr/src/slime/swank-loader.lisp
-# --eval '(swank-loader:init)'
-# --eval '(swank:create-server :dont-close t :interface "0.0.0.0")'
-
 services:
   sbcl:
     build:
@@ -20,6 +10,7 @@ services:
       args:
         UID: 1000
         GID: 1000
+      target: dev
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
This PR simplifies the multistage Dockerfile (which I couldn't successfully build) to a single file. 

It adds a docker-compose build, which can be used to build and start a dockerized SBCL, which you can then `slime-connect` to,

Finally, it adds a github workflow to build the images for both x86 and ARM architectures.