### PR TITLE
refactor give-up-compilation to remove frivolous :because kwarg

### DIFF
--- a/src/compilation-methods.lisp
+++ b/src/compilation-methods.lisp
@@ -43,11 +43,8 @@
   (:documentation "This is signaled when a rewriting rule cannot be applied to an instruction sequence."))
 
 
-(defun give-up-compilation (&key (because ':unknown))
-  (ecase because
-    (:invalid-domain         (error 'compiler-invalid-domain))
-    (:acts-trivially         (error 'compiler-acts-trivially))
-    (:unknown                (error 'compiler-does-not-apply))))
+(defun give-up-compilation (&optional (condition 'compiler-does-not-apply))
+  (error condition))
 
 
 ;;; Core routines governing how a chip-specification's compiler list is walked

--- a/src/compilers/approx.lisp
+++ b/src/compilers/approx.lisp
@@ -704,7 +704,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
 (define-compiler canonical-decomposition
     ((instr (_ _ q1 q0)))
   (handler-case
-      (let* ((m (or (gate-matrix instr) (give-up-compilation :because ':invalid-domain)))
+      (let* ((m (or (gate-matrix instr) (give-up-compilation 'compiler-invalid-domain)))
              (m (magicl:scale m (expt (magicl:det m) -1/4))))
         (multiple-value-bind (a d b) (orthogonal-decomposition m)
           (let ((canonical-coords (get-canonical-coords-from-diagonal d)))
@@ -718,7 +718,7 @@ Additionally, if PREDICATE evaluates to false and *ENABLE-APPROXIMATE-COMPILATIO
               (inst "A0"  (gate-matrix a0) q0)
               (inst "A1"  (gate-matrix a1) q1)))))
     (unknown-gate-parameter ()
-      (give-up-compilation :because ':invalid-domain))))
+      (give-up-compilation 'compiler-invalid-domain))))
 
 (defun approximate-2Q-compiler (crafters instr &key context)
   "Generic logic for performing (approximate) two-qubit compilation.  This consumes an instruction INSTR to compile, an optional CHIP-SPEC of type CHIP-SPECIFICATION which records fidelity information, and a list of circuit template manufacturers CRAFTERS to run through.

--- a/src/compilers/permutation.lisp
+++ b/src/compilers/permutation.lisp
@@ -190,7 +190,7 @@ in accordance with how Quil interprets a gate application."
            ;; controlled Toffoli gate, so we didn't do anything and
            ;; should give up.
            (when (and code (null (rest code)))
-             (give-up-compilation :because :acts-trivially))
+             (give-up-compilation 'compiler-acts-trivially))
            code))
         (t
-         (give-up-compilation :because :invalid-domain))))))
+         (give-up-compilation 'compiler-invalid-domain))))))


### PR DESCRIPTION
This change offers a resolution to the complaint of #333. The refactor assumes that the complaint had to do with the frivolity of the mapping keyword names to error signalling forms.  

If, however, the complaint was more involved - e.g. that there is an additional function call for signalling errors - then the form could be changed into a macro. It doesn't seem that the function bound to `give-up-compilation` is ever being used as a function value, so replacing it with a macro call should cause no difficulty.