### PR TITLE
Add: sqisw-decompose compiler

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -56,6 +56,7 @@
                              (:file "truth-table")
                              (:file "linear-reversible-circuits")
                              (:file "permutation")
+                             (:file "sqisw-decomposition")
                              ;; attic'd files / pedagogical purposes only
                              (:static-file "optimal-2q")
                              (:static-file "cs-compile")))

--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -27,7 +27,7 @@
                #:cl-heap
                #:cl-permutation
                #:queues.priority-queue
-               )
+               #:magicl/ext-expokit)
   :in-order-to ((asdf:test-op (asdf:test-op #:cl-quil-tests)))
   :around-compile (lambda (compile)
                     (let (#+sbcl (sb-ext:*derive-function-types* t))

--- a/src/compilers/sqisw-decomposition.lisp
+++ b/src/compilers/sqisw-decomposition.lisp
@@ -35,7 +35,7 @@ Where L(x,y,z) is the canonical representative of the class with coordinates x,y
                          (sqrt (/ (* 4 cos-x-sq cos-z-sq sin-y-sq)
                                   (+ (* 4 cos-x-sq cos-z-sq sin-y-sq)
                                      (* cos2x cos2y cos2z))))))))
-    (values
+    (list
      (list (build-gate "RZ" (list gamma) q0)
            (build-gate "RX" (list alpha) q0 )
            (build-gate "RZ" (list gamma) q0))
@@ -51,7 +51,6 @@ Where L(x,y,z) is the canonical representative of the class with coordinates x,y
 
 (defun canonicalize-for-sqisw (x0 y0 z0 q0 q1)
   "x0 y0 and z0 are canonical parameters in the Weyl chamber satisfying pi/4 >= x >= |z|. q0 and q1 are qubit indices.
-
   
 Returns 9 values. x y z A0 A1 B0 B1 C0 C1 with the following interpretation.  
 If x0,y0,z0 are canonical paramters for an arbitrary 2 qubit gate, then that gate is equivalent to 

--- a/src/compilers/sqisw-decomposition.lisp
+++ b/src/compilers/sqisw-decomposition.lisp
@@ -1,0 +1,181 @@
+;;;; sqisw-decomposition.lisp
+;;;;
+;;;; Author: Colin O'Keefe Following the algorithm outlined in
+;;;; https://arxiv.org/pdf/2105.06074.pdf, Supplemental Material, I.B.
+
+(in-package #:cl-quil)
+
+(defun interleaving-1-qubit-gates (x y z q0 q1)
+  "x y and z are canonical parameters in the Weyl chamber satisfying pi/4 >= x >= y >= |z|. Furthermore, this function assumes that the class of gates indicated by x,y,z falls within the span of 2 SQISW gates, which is equivalent to the additional condtion that x >= y + |z|. 
+
+q0 and q1 are qubit indices
+
+Returns two values L0 and L1, both lists of single-qubit gate applications, acting on q0 and q1 respectively. 
+L0 is a list of three rotations RZ(γ) RX(α) RZ(θ), and L1 is a list containing one RX(β).
+
+L(x,y,z) ~ SQiSW [ RZ(γ)RX(α)RZ(γ) ⊗ RX(β)] SQiSW
+
+Where L(x,y,z) is the canonical representative of the class with coordinates x,y, and z."
+  (declare (type double-float x y z))
+  (assert (xyz-in-2-sqisw-span-p x y z) () "~a ~a ~a not in the span of 2 SQISW gates." x y z)
+  (let* ((c (* (sin (+ x y (- z)))
+               (sin (+ x (- y) z))
+               (sin (+ (- x) (- y) (- z)))
+               (sin (+ (- x) y z))))
+         (cos2x (cos (* 2 x)))
+         (cos2y (cos (* 2 y)))
+         (cos2z (cos (* 2 z)))
+         (cos-x-sq (* (cos x) (cos x)))
+         (cos-z-sq (* (cos z) (cos z)))
+         (sin-y-sq (* (sin y) (sin y)))
+         (2-sqrt-c (* 2 (sqrt c)))
+         (alpha (acos (+ cos2x (- cos2y) cos2z 2-sqrt-c)))
+         (beta (acos (+ cos2x (- cos2y) cos2z (- 2-sqrt-c))))
+         (gamma (acos (* (cond ((plusp z) 1d0) ((minusp z) -1d0) (t 0d0)) ; sign(z)
+                         (sqrt (/ (* 4 cos-x-sq cos-z-sq sin-y-sq)
+                                  (+ (* 4 cos-x-sq cos-z-sq sin-y-sq)
+                                     (* cos2x cos2y cos2z))))))))
+    (values
+     (list (build-gate "RZ" (list gamma) q0)
+           (build-gate "RX" (list alpha) q0 )
+           (build-gate "RZ" (list gamma) q0))
+     (list (build-gate "RX" (list beta) q1)))))
+
+
+(defun xyz-in-2-sqisw-span-p (x y z)
+  (and (in-weyl-chamber-p x y z)
+       (>= x (+ y (abs z)))))
+
+(defun in-weyl-chamber-p (x y z)
+  (>= #.(/ pi 4.0d0) x y (abs z)))
+
+(defun canonicalize-for-sqisw (x0 y0 z0 q0 q1)
+  "x0 y0 and z0 are canonical parameters in the Weyl chamber satisfying pi/4 >= x >= |z|. q0 and q1 are qubit indices.
+
+  
+Returns 9 values. x y z A0 A1 B0 B1 C0 C1 with the following interpretation.  
+If x0,y0,z0 are canonical paramters for an arbitrary 2 qubit gate, then that gate is equivalent to 
+
+     [A0 ⊗ A1] L(x,y,z) [C0 ⊗ C1] SQiSW [B0 ⊗ B1] 
+
+where L(x,y,z) is the canoncal representative of the class for whose
+coordinates are x,y,z and is also a gate in the span of two SQiSW
+applications.
+"
+  (assert (in-weyl-chamber-p x0 y0 z0) () "~a, ~a, ~a are not in the Weyl Chamber" x0 y0 z0)
+  (let ((A0 (list))                     ; essentially, the identity
+        (A1 (list))
+        (B0 (list (build-gate "RY" (list -pi/2) q0)))
+        (B1 (list (build-gate "RY" (list pi/2) q1)))
+        (C0 (list (build-gate "RY" (list  pi/2) q0 )))
+        (C1 (list (build-gate "RY" (list -pi/2) q1)))
+        (x x0)
+        (y y0)
+        (z (abs z0)))
+    (if
+     (> x pi/8)
+     (setf y (- y pi/8 )
+           z (- z pi/8)
+           B0 (nconc B0 (list (build-gate "RZ" (list pi/2) q0))) ; order is order of application. i.e. apply B0 first
+           B1 (nconc B1 (list (build-gate "RZ" (list -pi/2) q1)))
+           C0 (cons (build-gate "RZ" (list -pi/2) q0) C0)
+           C1 (cons (build-gate "RZ" (list pi/2) q1) C1))
+     (setf x (+ x pi/8)
+           z (- z pi/8)))
+
+    (when (< (abs y) (abs z))
+      (let ((tmp y))
+        (setf y (* -1 z)
+              z (* -1 tmp)
+              A0 (list (build-gate "RX" (list pi/2) q0))
+              A1 (list (build-gate "RX" (list -pi/2) q1))
+              B0 (nconc B0 (list (build-gate "RX" (list -pi/2) q0)))
+              B1 (nconc B1 (list (build-gate "RX" (list pi/2) q1))))))
+    
+    (when (minusp z0)
+      (setf z (* -1 z)
+            A0 (append (list (build-gate "Z" () q0)) A0 (list (build-gate "Z" () q0)))
+            B0 (append (list (build-gate "Z" () q0)) B0 (list (build-gate "Z" () q0)))
+            C1 (append (list (build-gate "Z" () q1)) C1 (list (build-gate "Z" () q1 )))))
+    (list x y z A0 A1 B0 B1 C0 C1)))
+
+
+(define-compiler sqisw-decompose
+    ((instr (_ _ q1 q0)))
+  "This compiler will produce a sequence containing at most two SQISW
+applications whenever possible, and, when it cannot, is guaranteed to
+produce a sequence containing at most three SQiSW applications."
+  (destructuring-bind
+      (b0 b1 can1 a0 a1) (canonical-decomposition instr)
+    (destructuring-bind
+        ;; making an assumption that I can divide by two here.
+        ;; TODO: check that this isn't bunk.
+        (x y z) (loop :for p :in (application-parameters can1)
+                      :collect (/ (constant-value p) 2d0))
+      (cond
+        ((<= (abs z) (- x y))
+         (destructuring-bind
+             (c0 c1) (interleaving-1-qubit-gates x y z q0 q1)
+           (let ((v (append (list (build-gate "SQISW" () q1 q0))
+                            c0 c1
+                            (list (build-gate "SQISW" () q1 q0)))))
+             (destructuring-bind
+                 (e0 e1 can2 d0 d1) (canonical-decomposition (anon-gate "V" (make-matrix-from-quil v)  q1 q0))
+               (declare (ignore can2))
+               (inst b0)
+               (inst (anon-gate "E0t" (magicl:conjugate-transpose (gate-matrix e0)) q0))
+               (inst b1)
+               (inst (anon-gate "E1t" (magicl:conjugate-transpose (gate-matrix e1)) q1))
+               (inst "SQISW" () q1 q0)
+               (mapc #'inst c0)
+               (mapc #'inst c1)
+               (inst "SQISW" () q1 q0)
+               (inst (anon-gate "D0t" (magicl:conjugate-transpose (gate-matrix d0)) q0))
+               (inst a0)
+               (inst (anon-gate "D1t" (magicl:conjugate-transpose (gate-matrix d1)) q1))
+               (inst a1)))))
+
+        (t
+         (destructuring-bind
+             (cx cy cz f0 f1 g0 g1 h0 h1) (canonicalize-for-sqisw x y z q0 q1)
+           (destructuring-bind
+               (c0 c1) (interleaving-1-qubit-gates cx cy cz q0 q1)
+             (let ((v (append (list (build-gate "SQISW" () q1 q0))
+                              c0 c1
+                              (list (build-gate "SQISW" () q1 q0)))))
+               (destructuring-bind
+                   (e0 e1 can2 d0 d1) (canonical-decomposition (anon-gate "V" (make-matrix-from-quil v) q1 q0))
+                 (declare (ignore can2))
+                 (inst b0)
+                 (mapc #'inst h0)
+                 (inst b1)
+                 (mapc #'inst h1)
+                 (inst "SQISW" () q1 q0)
+                 (mapc #'inst g0)
+                 (inst (anon-gate "E0t" (magicl:conjugate-transpose (gate-matrix e0)) q0))
+                 (mapc #'inst g1)
+                 (inst (anon-gate "E1t" (magicl:conjugate-transpose (gate-matrix e1)) q1))
+                 (inst "SQISW" () q1 q0)
+                 (mapc #'inst c0)
+                 (mapc #'inst c1)
+                 (inst "SQISW" () q1 q0)
+                 (inst (anon-gate "D0t" (magicl:conjugate-transpose (gate-matrix d0)) q0))
+                 (mapc #'inst f0)
+                 (inst a0)
+                 (inst (anon-gate "D1t" (magicl:conjugate-transpose (gate-matrix d1)) q1))
+                 (mapc #'inst f1)
+                 (inst a1))))))))))
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/compilers/sqisw-decomposition.lisp
+++ b/src/compilers/sqisw-decomposition.lisp
@@ -1,23 +1,54 @@
 ;;;; sqisw-decomposition.lisp
 ;;;;
-;;;; Author: Colin O'Keefe Following the algorithm outlined in
-;;;; https://arxiv.org/pdf/2105.06074.pdf, Supplemental Material, I.B.
+;;;; Author: Colin O'Keefe Following the algorithm outlined in Huang
+;;;; et al, https://arxiv.org/pdf/2105.06074.pdf, Supplemental
+;;;; Material, I.B.
 
 (in-package #:cl-quil)
 
+;; Some defintions for making sense of comments and docstrings:
+;;
+;; L(p,q,r) is the canonical representative of the class with
+;; coordinates are p,q,r.  Specifically, Huang et al define this to be
+;;
+;; L(p,q,r) = exp(i[p,q,r]·Σ)  where Σ = [X⊗X, Y⊗Y, Z⊗Z]
+;;
+;; Let  CAN(a,b,c) be the standard quil CAN gate.
+;; Let Coords(M) be the canonical coordinates (a,b,c) such that M = A·CAN(a,b,c)·B
+;; Then Coords(L(a/2,b/2,c/2)) = (a,b,c):
+;;
+;; (loop repeat 10000
+;;       for coords = (canonical-coords (random-unitary 4) 1 0)
+;;       for repcoords = (canonical-coords
+;;                        (apply 'canonical-representative-huang-et-al
+;;                               (mapcar (lambda (x) (/ x 2)) coords))
+;;                        1 0)
+;;       always (every 'double= coords repcoords))
+;;
+;; Hence L(a/2,b/2,c/2) = A·CAN(a,b,c)·B for some A,B ∈ SU(2)⊗SU(2)
+;;
+;; Let ~ denote "local equivalence".
+
+
 (defun interleaving-1-qubit-gates (x y z q0 q1)
-  "x y and z are canonical parameters in the Weyl chamber satisfying pi/4 >= x >= y >= |z|. Furthermore, this function assumes that the class of gates indicated by x,y,z falls within the span of 2 SQISW gates, which is equivalent to the additional condtion that x >= y + |z|. 
+  "x y and z are canonical parameters in the Weyl chamber satisfying
+pi/4 >= x >= y >= |z|. Furthermore, this function assumes that the
+class of gates indicated by x,y,z falls within the span of 2 SQISW
+gates, which is equivalent to the additional condtion that x >= y + |z|.
 
-q0 and q1 are qubit indices
+q0 and q1 are qubit indices.
 
-Returns two values L0 and L1, both lists of single-qubit gate applications, acting on q0 and q1 respectively. 
-L0 is a list of three rotations RZ(γ) RX(α) RZ(θ), and L1 is a list containing one RX(β).
+Returns a list of two members, L0 and L1, both lists of single-qubit
+gate applications, acting on q0 and q1 respectively.  L0 is a list of
+three rotations RZ(γ) RX(α) RZ(γ), and L1 is a list containing one
+RX(β).
 
 L(x,y,z) ~ SQiSW [ RZ(γ)RX(α)RZ(γ) ⊗ RX(β)] SQiSW
 
+NOTE: the above is '~' not '='
+
 Where L(x,y,z) is the canonical representative of the class with coordinates x,y, and z."
   (declare (type double-float x y z))
-  (assert (xyz-in-2-sqisw-span-p x y z) () "~a ~a ~a not in the span of 2 SQISW gates." x y z)
   (let* ((c (* (sin (+ x y (- z)))
                (sin (+ x (- y) z))
                (sin (+ (- x) (- y) (- z)))
@@ -31,7 +62,7 @@ Where L(x,y,z) is the canonical representative of the class with coordinates x,y
          (2-sqrt-c (* 2 (sqrt c)))
          (alpha (acos (+ cos2x (- cos2y) cos2z 2-sqrt-c)))
          (beta (acos (+ cos2x (- cos2y) cos2z (- 2-sqrt-c))))
-         (gamma (acos (* (cond ((plusp z) 1d0) ((minusp z) -1d0) (t 0d0)) ; sign(z)
+         (gamma (acos (* (if (minusp z) -1 1) ; sign(z)
                          (sqrt (/ (* 4 cos-x-sq cos-z-sq sin-y-sq)
                                   (+ (* 4 cos-x-sq cos-z-sq sin-y-sq)
                                      (* cos2x cos2y cos2z))))))))
@@ -42,26 +73,69 @@ Where L(x,y,z) is the canonical representative of the class with coordinates x,y
      (list (build-gate "RX" (list beta) q1)))))
 
 
-(defun xyz-in-2-sqisw-span-p (x y z)
-  (and (in-weyl-chamber-p x y z)
-       (>= x (+ y (abs z)))))
+(define-compiler canonical-to-2-sqisw
+    ((instr ("CAN" (x y z) q1 q0)
+            :where (<= (abs z) (- x y))))
+  (destructuring-bind
+      (c0 c1) (interleaving-1-qubit-gates (/ x 2.0d0) (/ y 2.0d0) (/ z 2.0d0) q0 q1) ; L(v/2) ~ CAN(v)
+    (destructuring-bind
+        (e0 e1 can2 d0 d1)
+        (canonical-decomposition
+         (anon-gate "V" (make-matrix-from-quil
+                         (append
+                          (list (build-gate "SQISW" () q1 q0))
+                          c0 c1
+                          (list (build-gate "SQISW" () q1 q0))))
+                    q1 10))
+      (declare (ignore can2))
+      (inst (anon-gate "E0t" (magicl:conjugate-transpose (gate-matrix e0)) q0))
+      (inst (anon-gate "E1t" (magicl:conjugate-transpose (gate-matrix e1)) q1))
+      (inst "SQISW" () q1 q0)
+      (mapc #'inst c0)
+      (mapc #'inst c1)
+      (inst "SQISW" () q1 q0)
+      (inst (anon-gate "D0t" (magicl:conjugate-transpose (gate-matrix d0)) q0))
+      (inst (anon-gate "D1t" (magicl:conjugate-transpose (gate-matrix d1)) q1)))))
 
-(defun in-weyl-chamber-p (x y z)
-  (>= #.(/ pi 4.0d0) x y (abs z)))
+;; A little inline test of the canonical to 2 swisw compiler
+;; (loop
+;;   for (a b c) = (list (random pi/2) (random pi/2) (random pi/2))
+;;   for should-apply? =  (and (quil-canonical-p a b c)
+;;                             (<= (abs c) (- a b)))
+;;   for gate = (build-gate "CAN" (list a b c) 1 0)
+;;   when should-apply?
+;;     count 1 into samples
+;;   when (and  should-apply?
+;;              (matrix-equals-dwim
+;;               (gate-matrix gate)
+;;               (make-matrix-from-quil (canonical-to-2-sqisw gate))))
+;;     count 1 into matches
+;;   until (= 1000 samples)
+;;   finally (assert (= samples matches)))
+
+
 
 (defun canonicalize-for-sqisw (x0 y0 z0 q0 q1)
-  "x0 y0 and z0 are canonical parameters in the Weyl chamber satisfying pi/4 >= x >= |z|. q0 and q1 are qubit indices.
-  
-Returns 9 values. x y z A0 A1 B0 B1 C0 C1 with the following interpretation.  
-If x0,y0,z0 are canonical paramters for an arbitrary 2 qubit gate, then that gate is equivalent to 
+  "x0 y0 and z0 are canonical parameters in the Weyl chamber satisfying
+pi/4 >= x >= |z|.  q0 and q1 are qubit indices.
 
-     [A0 ⊗ A1] L(x,y,z) [C0 ⊗ C1] SQiSW [B0 ⊗ B1] 
+Returns a list of 9 values. (x y z A0 A1 B0 B1 C0 C1) with the
+following interpretation.
 
-where L(x,y,z) is the canoncal representative of the class for whose
-coordinates are x,y,z and is also a gate in the span of two SQiSW
-applications.
-"
-  (assert (in-weyl-chamber-p x0 y0 z0) () "~a, ~a, ~a are not in the Weyl Chamber" x0 y0 z0)
+The Ai,Bi,Ci for i ∈ {0,1} are lists of single qubit gate applications
+acting on qi, listed in the order they are applied.  As a shorthand,
+below I use Gi to mean the gate obtained by applying gates
+in Gi.
+
+If x0,y0,z0 are canonical paramters for an arbitrary 2 qubit gate,
+then
+
+   L(x0,y0,z0) =  [A0 ⊗ A1]·L(x,y,z)·[B0 ⊗ B1]·SQiSW·[C0 ⊗ C1]
+
+
+Furthermore, the returned x,y,z, we have that L(x,y,z) is a gate in
+the span of two SQiSW applications."
+  (declare (type double-float x0 y0 z0))
   (let ((A0 (list))                     ; essentially, the identity
         (A1 (list))
         (B0 (list (build-gate "RY" (list -pi/2) q0)))
@@ -71,110 +145,114 @@ applications.
         (x x0)
         (y y0)
         (z (abs z0)))
-    (if
-     (> x pi/8)
-     (setf y (- y pi/8 )
-           z (- z pi/8)
-           B0 (nconc B0 (list (build-gate "RZ" (list pi/2) q0))) ; order is order of application. i.e. apply B0 first
-           B1 (nconc B1 (list (build-gate "RZ" (list -pi/2) q1)))
-           C0 (cons (build-gate "RZ" (list -pi/2) q0) C0)
-           C1 (cons (build-gate "RZ" (list pi/2) q1) C1))
-     (setf x (+ x pi/8)
-           z (- z pi/8)))
+
+    (if (> x pi/8)
+        (setf y (- y pi/8)
+              z (- z pi/8)
+              B0 (nconc B0 (list (build-gate "RZ" (list pi/2) q0))) ; order is order of application. i.e. apply B0 first
+              B1 (nconc B1 (list (build-gate "RZ" (list -pi/2) q1)))
+              C0 (cons (build-gate "RZ" (list -pi/2) q0) C0)
+              C1 (cons (build-gate "RZ" (list pi/2) q1) C1))
+        (setf x (+ x pi/8)
+              z (- z pi/8)))
 
     (when (< (abs y) (abs z))
       (let ((tmp y))
-        (setf y (* -1 z)
-              z (* -1 tmp)
+        (setf y (* -1d0 z)
+              z (* -1d0 tmp)
               A0 (list (build-gate "RX" (list pi/2) q0))
               A1 (list (build-gate "RX" (list -pi/2) q1))
               B0 (nconc B0 (list (build-gate "RX" (list -pi/2) q0)))
               B1 (nconc B1 (list (build-gate "RX" (list pi/2) q1))))))
-    
+
     (when (minusp z0)
-      (setf z (* -1 z)
-            A0 (append (list (build-gate "Z" () q0)) A0 (list (build-gate "Z" () q0)))
+      (setf z (* -1d0 z)
+            A0 (when A0 (append (list (build-gate "Z" () q0)) A0 (list (build-gate "Z" () q0))))
             B0 (append (list (build-gate "Z" () q0)) B0 (list (build-gate "Z" () q0)))
-            C1 (append (list (build-gate "Z" () q1)) C1 (list (build-gate "Z" () q1 )))))
+            C0 (append (list (build-gate "Z" () q1)) C0 (list (build-gate "Z" () q1 )))))
+
     (list x y z A0 A1 B0 B1 C0 C1)))
 
 
+
+(defun dagger-inst-name (g)
+  (let ((name (application-operator-name g)))
+   (format nil "DAGGER-~a"
+           (subseq name 0
+                   (1+ (position-if #'alpha-char-p name :from-end t))))))
+
+(defun dagger-inst (g)
+  "G should be a gate application. Creates an anonymouse gate whose
+matrix is the conjugate transpose of G's matrix. "
+  (apply 'anon-gate (dagger-inst-name g)
+         (magicl:dagger (gate-matrix g))
+         (application-arguments g)))
+
 (define-compiler sqisw-decompose
     ((instr (_ _ q1 q0)))
-  "This compiler will produce a sequence containing at most two SQISW
-applications whenever possible, and, when it cannot, is guaranteed to
-produce a sequence containing at most three SQiSW applications."
   (destructuring-bind
-      (b0 b1 can1 a0 a1) (canonical-decomposition instr)
-    (destructuring-bind
-        ;; making an assumption that I can divide by two here.
-        ;; TODO: check that this isn't bunk.
-        (x y z) (loop :for p :in (application-parameters can1)
-                      :collect (/ (constant-value p) 2d0))
-      (cond
-        ((<= (abs z) (- x y))
-         (destructuring-bind
-             (c0 c1) (interleaving-1-qubit-gates x y z q0 q1)
-           (let ((v (append (list (build-gate "SQISW" () q1 q0))
-                            c0 c1
-                            (list (build-gate "SQISW" () q1 q0)))))
-             (destructuring-bind
-                 (e0 e1 can2 d0 d1) (canonical-decomposition (anon-gate "V" (make-matrix-from-quil v)  q1 q0))
-               (declare (ignore can2))
-               (inst b0)
-               (inst (anon-gate "E0t" (magicl:conjugate-transpose (gate-matrix e0)) q0))
-               (inst b1)
-               (inst (anon-gate "E1t" (magicl:conjugate-transpose (gate-matrix e1)) q1))
-               (inst "SQISW" () q1 q0)
-               (mapc #'inst c0)
-               (mapc #'inst c1)
-               (inst "SQISW" () q1 q0)
-               (inst (anon-gate "D0t" (magicl:conjugate-transpose (gate-matrix d0)) q0))
-               (inst a0)
-               (inst (anon-gate "D1t" (magicl:conjugate-transpose (gate-matrix d1)) q1))
-               (inst a1)))))
+      (b0 b1 can a0 a1) (canonical-decomposition instr)
+    (destructuring-bind (x y z) (mapcar #'constant-value (application-parameters can))
+      ;; M = (A0 ⊗ A1)·CAN(x,y,z)·(B0 ⊗ B1)
+      (destructuring-bind
+          (cx cy cz F0 F1 G0 G1 H0 H1) (canonicalize-for-sqisw (/ x 2.0d0) (/ y 2.0d0) (/ z 2.0d0) q0 q1)
+        ;; L(x/2,y/2,z/2) = (F0 ⊗ F1)·L(cx,cy,cz)·(G0 ⊗ G1)·SQISW·(H0 ⊗ H1)
+        ;; so we need to get the decomposition of these L(-) terms.
+        (destructuring-bind
+            (D0 D1 _can C0 C1) (canonical-decomposition
+                                (canonical-gate-haung-et-al
+                                 (/ x 2.0d0) (/ y 2.0d0) (/ z 2.0d0)
+                                 1 0))
+          (declare (ignore _can)) ;; same CAN as above
+          ;; So that
+          ;; CAN(x,y,z) = (C0 ⊗ C1)⁺L(x/2,y/2,z/2)·(D0 ⊗ D1)⁺
+          ;; hence
+          ;; M = (A0 ⊗ A1)·(C0 ⊗ C1)⁺·(F0 ⊗ F1)·L(cx,cy,cz)·(G0 ⊗ G1)·SQISW·(H0 ⊗ H1)·(D0 ⊗ D1)⁺·(B0 ⊗ B1)
+          ;;   = (A0C0⁺F0 ⊗ A1C1⁺F1)·L(cx,cy,cz)·(G0 ⊗ G1)·SQISW·(H0D0⁺B0 ⊗ H1D1⁺B1)
+          (inst b0)
+          (inst (dagger-inst d0))
+          (mapc #'inst h0)
+          (inst b1)
+          (inst (dagger-inst d1))
+          (mapc #'inst h1)
+          (inst "SQISW" () q1 q0)
+          (mapc #'inst g0)
+          (mapc #'inst g1)
 
-        (t
-         (destructuring-bind
-             (cx cy cz f0 f1 g0 g1 h0 h1) (canonicalize-for-sqisw x y z q0 q1)
-           (destructuring-bind
-               (c0 c1) (interleaving-1-qubit-gates cx cy cz q0 q1)
-             (let ((v (append (list (build-gate "SQISW" () q1 q0))
-                              c0 c1
-                              (list (build-gate "SQISW" () q1 q0)))))
-               (destructuring-bind
-                   (e0 e1 can2 d0 d1) (canonical-decomposition (anon-gate "V" (make-matrix-from-quil v) q1 q0))
-                 (declare (ignore can2))
-                 (inst b0)
-                 (mapc #'inst h0)
-                 (inst b1)
-                 (mapc #'inst h1)
-                 (inst "SQISW" () q1 q0)
-                 (mapc #'inst g0)
-                 (inst (anon-gate "E0t" (magicl:conjugate-transpose (gate-matrix e0)) q0))
-                 (mapc #'inst g1)
-                 (inst (anon-gate "E1t" (magicl:conjugate-transpose (gate-matrix e1)) q1))
-                 (inst "SQISW" () q1 q0)
-                 (mapc #'inst c0)
-                 (mapc #'inst c1)
-                 (inst "SQISW" () q1 q0)
-                 (inst (anon-gate "D0t" (magicl:conjugate-transpose (gate-matrix d0)) q0))
-                 (mapc #'inst f0)
-                 (inst a0)
-                 (inst (anon-gate "D1t" (magicl:conjugate-transpose (gate-matrix d1)) q1))
-                 (mapc #'inst f1)
-                 (inst a1))))))))))
+          (mapc #'inst (canonical-decomposition
+                        (canonical-gate-haung-et-al
+                         cx cy cz 1 0)))
+
+          (mapc #'inst f0)
+          (inst (dagger-inst c0))
+          (inst a0)
+          (mapc #'inst f1)
+          (inst (dagger-inst c1))
+          (inst a1))))))
+
+;; (loop
+;;   repeat 1000
+;;   for m = (random-unitary 4)
+;;   when (matrix-equals-dwim
+;;         m
+;;         (make-matrix-from-quil (sqisw-decompose (anon-gate "ANON" m 1 0))))
+;;     count 1)
 
 
 
 
+(defun canonical-representative-huang-et-al (x y z)
+  (let ((sigma (mapcar #'magicl:kron
+                       (list pauli-x pauli-y pauli-z)
+                       (list pauli-x pauli-y pauli-z))))
+    (magicl:expm
+     (magicl:.* (sqrt -1)
+                (reduce #'magicl:.+
+                        (mapcar #'magicl:.*
+                                (list x y z)
+                                sigma))))))
 
-
-
-
-
-
-
-
-
-
+(defun canonical-gate-haung-et-al (x y z q1 q0)
+  (anon-gate (format nil "L(~a,~a,~a)" x y z)
+             (canonical-representative x y z)
+             q1 q0))

--- a/src/frontend-utilities.lisp
+++ b/src/frontend-utilities.lisp
@@ -154,8 +154,10 @@ contains the bits of INTEGER. See http://www.cliki.net/ROTATE-BYTE"
   (define-self-documenting-constant -pi   (- pi))
   (define-self-documenting-constant pi/2  (/ pi 2))
   (define-self-documenting-constant -pi/2 (/ pi -2))
+  (define-self-documenting-constant pi/8  (/ pi 8))
+  (define-self-documenting-constant -pi/8 (/ pi -8))
   (define-self-documenting-constant 2pi   (* 2 pi))
-  (define-self-documenting-constant 4pi   (* 4 pi)))
+  (define-self-documenting-constant 4pi   (* 4 pi))) 
 
 ;;; some of the analysis code uses this, otherwise this might belong in cl-quil proper
 (defconstant +double-comparison-threshold-loose+  1d-5)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -72,6 +72,8 @@
    #:-pi                                ; CONSTANT
    #:pi/2                               ; CONSTANT
    #:-pi/2                              ; CONSTANT
+   #:pi/8                               ; CONSTANT 
+   #:-pi/8                              ; CONSTANT 
    #:2pi                                ; CONSTANT
    #:4pi                                ; CONSTANT
    #:double-float-positive-infinity     ; CONSTANT

--- a/src/quil/stdgates.quil
+++ b/src/quil/stdgates.quil
@@ -162,3 +162,10 @@ DEFGATE BLOCH(%alpha, %beta, %gamma) q AS PAULI-SUM:
     X(%alpha) q
     Y(%beta) q
     Z(%gamma) q
+
+DEFGATE SQISW:
+    1, 0,         0,         0
+    0, 1/sqrt(2), i/sqrt(2), 0
+    0, i/sqrt(2), 1/sqrt(2), 0
+    0, 0,         0,         1
+


### PR DESCRIPTION
This branch intends to add sqisw decomposition to quilc, as per #766 . 

What remains to be done: 
- [ ] separate `define-compiler` defs for specific known gates 
- [ ] tests passing
- [ ] amendments and alterations per review and critique 

What has been done so far: A `define-compiler` definition has been added that decomposes an arbitrary 2 qubit gate into at most three SQiSW gates interleaved by single qubit gates, and, for 80% of all 2 qubit gates, only requires two SQiSW gates. 

As this is my first attempt to contribute to the compiler, I am looking for critique on anything that is obviously wrong or obviously flouting conventions. 