### PR TITLE
fixes (for) boondoggle: quil -> cl-quil; workaround in print-program

### DIFF
--- a/boondoggle/src/consumers.lisp
+++ b/boondoggle/src/consumers.lisp
@@ -5,7 +5,7 @@
 ;;; The main job of this file is to provide interfaces to different
 ;;; execution environments for Quil, currently just the local QVM.  We
 ;;; provide a generic `consume-quil` method that takes a
-;;; `quil::parsed-program` object and returns probability amplitudes
+;;; `cl-quil::parsed-program` object and returns probability amplitudes
 ;;; as sterilized output.
 
 (in-package #:boondoggle)
@@ -31,10 +31,10 @@
   (:documentation "Returns a list of amplitude registered associated to a consumer.")
   (:method ((consumer consumer-local-qvm) parsed-program)
     (remove-duplicates
-    (loop :for instr :across (quil::parsed-program-executable-code parsed-program)
-          :when (typep instr 'quil::measure)
-            :collect (quil::memory-ref-position
-                      (quil::measure-address
+    (loop :for instr :across (cl-quil::parsed-program-executable-code parsed-program)
+          :when (typep instr 'cl-quil::measure)
+            :collect (cl-quil::memory-ref-position
+                      (cl-quil::measure-address
                        instr))))))
 
 (defmethod consume-quil ((consumer consumer-local-qvm) parsed-program)
@@ -45,7 +45,7 @@ For a program constructing a bell state with a large sampling count, the returne
     (:http
      (let* ((quil-instructions
               (with-output-to-string (s)
-                (quil::print-parsed-program parsed-program s)))
+                (cl-quil::print-parsed-program parsed-program s)))
             (classical-addresses
               (a:plist-hash-table
                 (list "ro" (get-consumer-registers consumer parsed-program))))

--- a/boondoggle/src/processors.lisp
+++ b/boondoggle/src/processors.lisp
@@ -20,11 +20,11 @@
 
 (defmethod apply-process ((processor processor-quilc) &rest data)
   (let ((data (first data)))
-    (quil::parse-quil
+    (cl-quil::parse-quil
      (uiop:run-program (processor-quilc-executable-path processor)
                        :input (make-string-input-stream
                                (with-output-to-string (s)
-                                 (quil::print-parsed-program data s)))
+                                 (cl-quil::print-parsed-program data s)))
                        :output :string))))
 
 (defclass processor-identity (processor)

--- a/boondoggle/src/producers.lisp
+++ b/boondoggle/src/producers.lisp
@@ -24,7 +24,7 @@ PARAMETER-BOUNDS is a list of maximum random values for the gate parameters."
   (error "This producer has not been implemented."))
 
 (defclass producer-random (producer)
-  ((chip-specification :initform (quil::build-8Q-chip)
+  ((chip-specification :initform (cl-quil::build-8Q-chip)
                        :initarg :chip-specification
                        :reader producer-random-chip-specification)
    (program-depth-limit :initform nil
@@ -67,10 +67,10 @@ PARAMETER-BOUNDS is a list of maximum random values for the gate parameters."
 
 (defun measure-at-close-instrs (chip-specification)
   "Apply MEASURE instructions on all qubits in a chip-specification. Assumes qubits are ordered from 0 to n with no skipped indices."
-  (loop :for j :below (quil::chip-spec-n-qubits chip-specification)
-        :collect (make-instance 'quil:measure
-                                :address (quil:mref "ro" j)
-                                :qubit (quil:qubit j))))
+  (loop :for j :below (cl-quil::chip-spec-n-qubits chip-specification)
+        :collect (make-instance 'cl-quil:measure
+                                :address (cl-quil:mref "ro" j)
+                                :qubit (cl-quil:qubit j))))
 
 (defun random-protoquil (chip-specification   ; chip topology
                          program-depth-limit  ; limit to randomly generated program depth
@@ -81,16 +81,16 @@ PARAMETER-BOUNDS is a list of maximum random values for the gate parameters."
                          respect-topology     ; place multiqubit gates only on chip-specification links
                          )
   "Generates random Quil strings to the statistics specifications set out by the argument list."
-  (let ((parsed-program (make-instance 'quil::parsed-program))
+  (let ((parsed-program (make-instance 'cl-quil::parsed-program))
         (instruction-list nil)
         (random-gate-count 0))
-    (dotimes (j (random program-volume-limit))
+    (loop repeat (random program-volume-limit) do
       ;; generate an instruction
       (let* ((random-gate-flag (< (random 1d0) random-gate-rate))
              (gate-record
                (unless random-gate-flag
                  (nth (random (length gate-set)) gate-set)))
-             (qubits-on-device (length (aref (quil::chip-specification-objects chip-specification) 0)))
+             (qubits-on-device (length (aref (cl-quil::chip-specification-objects chip-specification) 0)))
              (gate-name
                (cond
                  (random-gate-flag
@@ -115,12 +115,12 @@ PARAMETER-BOUNDS is a list of maximum random values for the gate parameters."
                  (respect-topology
                   (let* ((available-devices
                            (progn
-                             (assert (elt (quil::chip-specification-objects chip-specification) gate-order)
+                             (assert (elt (cl-quil::chip-specification-objects chip-specification) gate-order)
                                      nil
                                      "This gate spec expects higher order hardware objects to exist.")
-                             (elt (quil::chip-specification-objects chip-specification) gate-order)))
+                             (elt (cl-quil::chip-specification-objects chip-specification) gate-order)))
                          (device-index (random (length available-devices))))
-                    (quil::vnth 0 (quil::hardware-object-cxns (quil::vnth device-index available-devices)))))
+                    (cl-quil::vnth 0 (cl-quil::hardware-object-cxns (cl-quil::vnth device-index available-devices)))))
                  (t
                   (assert (< gate-order qubits-on-device)
                           nil
@@ -133,45 +133,48 @@ PARAMETER-BOUNDS is a list of maximum random values for the gate parameters."
                         :finally (return ret)))))
              (gate-definition
                (when random-gate-flag
-                 (let ((gate-matrix (quil::random-special-unitary (expt 2 (1+ gate-order)))))
-                   (quil::make-gate-definition gate-name
-                                               nil
-                                               (loop :for i :below (magicl:ncols gate-matrix)
-                                                     :nconc (loop :for j :below (magicl:nrows gate-matrix)
-                                                                  :collect (magicl:tref gate-matrix j i)))))))
+                 (let ((gate-matrix (cl-quil::random-special-unitary (expt 2 (1+ gate-order)))))
+                   (cl-quil.frontend::make-gate-definition
+                    gate-name
+                    nil
+                    (loop :for i :below (magicl:ncols gate-matrix)
+                          :nconc (loop :for j :below (magicl:nrows gate-matrix)
+                                       :collect (magicl:tref gate-matrix j i)))))))
              (gate-parameters
                (unless random-gate-flag
                  (mapcar #'random (gate-set-record-parameter-bounds gate-record))))
-             (gate-invocation (make-instance 'quil::gate-application
-                                             :operator (quil:named-operator gate-name)
-                                             :arguments (map 'list #'quil:qubit qubit-indices)
-                                             :parameters (map 'list #'quil:constant gate-parameters))))
+             (gate-invocation
+               (make-instance 'cl-quil::gate-application
+
+                              :operator (cl-quil:named-operator gate-name)
+                              :arguments (map 'list #'cl-quil:qubit qubit-indices)
+                              :parameters (map 'list #'cl-quil:constant gate-parameters))))
         (push gate-invocation instruction-list)
         ;; check to see if we need to bail because of depth
         (when (and
                program-depth-limit
                (< program-depth-limit
-                  (let ((lschedule (make-instance 'quil::lscheduler-empty)))
-                    (quil::append-instructions-to-lschedule lschedule instruction-list)
-                    (quil::lscheduler-calculate-depth lschedule))))
+                  (let ((lschedule (cl-quil::make-lscheduler)))
+                    (cl-quil::append-instructions-to-lschedule lschedule instruction-list)
+                    (cl-quil::lscheduler-calculate-depth lschedule))))
           (pop instruction-list)
           (return))
         ;; if we built a random gate, store its definition
         (when random-gate-flag
           (incf random-gate-count)
-          (push gate-definition (quil::parsed-program-gate-definitions parsed-program)))))
-    (setf (quil::parsed-program-executable-code parsed-program)
+          (push gate-definition (cl-quil::parsed-program-gate-definitions parsed-program)))))
+    (setf (cl-quil::parsed-program-executable-code parsed-program)
           (make-array (length instruction-list)
                       :initial-contents instruction-list))
     ;; Add readout memory definitions to the program
-    (push (quil::make-memory-descriptor
+    (push (cl-quil::make-memory-descriptor
                 :name "ro"
-                :type quil::quil-bit
-                :length (quil::chip-spec-n-qubits chip-specification))
-          (quil:parsed-program-memory-definitions parsed-program))
+                :type cl-quil::quil-bit
+                :length (cl-quil::chip-spec-n-qubits chip-specification))
+          (cl-quil:parsed-program-memory-definitions parsed-program))
     ;; Add measure instructions to the end of the program
-    (setf (quil::parsed-program-executable-code parsed-program)
+    (setf (cl-quil::parsed-program-executable-code parsed-program)
           (concatenate 'vector
-                       (quil::parsed-program-executable-code parsed-program)
+                       (cl-quil::parsed-program-executable-code parsed-program)
                        (measure-at-close-instrs chip-specification)))
     parsed-program))

--- a/src/print-program.lisp
+++ b/src/print-program.lisp
@@ -36,6 +36,7 @@
                                #'gate-application-gate
                                (remove-if-not (lambda (inst)
                                                 (and (typep inst 'gate-application)
+                                                     (slot-boundp inst 'name-resolution) ; TODO: this shouldn't be necessary
                                                      (typep (gate-application-gate inst)
                                                             'simple-gate)))
                                               (parsed-program-executable-code pp)))))


### PR DESCRIPTION
I ran the boondoggle tests like so:

    cd <path-to>/qvm 
    make qvm 
    ./qvm -S 

    #elsewere ...
    sbcl 
    > (ql:quickload :boondoggle-tests) 
    > (asdf:test-system :boondoggle) 

and they passed. 

Some notes: 
- I changed a `dotimes` to a `loop repeat` because unused and/or shadowed counter variables make me nervous. 
- I altered `print-parsed-program-generic` in a way that, in a more perfect world, would not be necessary, but that shouldn't hurt anything.