### PR TITLE
Add: pseudo-gate-application class

### DIFF
--- a/src/ast.lisp
+++ b/src/ast.lisp
@@ -1380,6 +1380,18 @@ N.B. This slot should not be accessed directly! Consider using GATE-APPLICATION-
     (t
      (assert (slot-boundp app 'gate) (app) "A gate application was made that doesn't have a definition. Please specify either its name resolution or a gate."))))
 
+(defclass pseudo-gate-application (gate-application)
+  ((gate :initform nil))
+  (:documentation "Represents a formal, \"stand-in\", gate-application instruction that will never be associated to an underlying gate."))
+
+(defmethod gate-application-gate ((app pseudo-gate-application))
+  (error "Attempted to return a GATE representation from a PSEUDO-GATE-APPLICATION instance: ~s" app))
+
+(defmethod gate-matrix ((app pseudo-gate-application) &rest params)
+  (declare (ignore params))
+  (warn "Attempted to return a MATRIX representation of a PSEUDO-GATE-APPLICATION instance: ~s" app)
+  nil)
+
 ;;; XXX FIXME TODO: This doesn't actually check that SWAP is the same
 ;;; one as defined in the standard, because there is no notion of a
 ;;; "resolved" environment.

--- a/src/compilers/state-prep.lisp
+++ b/src/compilers/state-prep.lisp
@@ -7,22 +7,16 @@
 
 (in-package #:cl-quil)
 
-(defclass state-prep-application (gate-application)
+(defclass state-prep-application (pseudo-gate-application)
   ((source-wf :initarg :source-wf
               :accessor state-prep-application-source-wf
               :documentation "Source wavefunction.")
    (target-wf :initarg :target-wf
               :accessor state-prep-application-target-wf
               :documentation "Target wavefunction."))
-  (:default-initargs :operator #.(named-operator "STATE-PREP")
-                     ;; XXX: Hack!
-                     :gate nil)
+  (:default-initargs :operator #.(named-operator "STATE-PREP"))
   (:documentation "A pseudo-instruction representing any state-preparation circuit that carries SOURCE-WF into TARGET-WF."))
 
-;;; XXX: Hack!
-(defmethod gate-matrix ((gate state-prep-application) &rest parameters)
-  (declare (ignore gate parameters))
-  nil)
 
 (defmethod print-instruction-generic ((thing state-prep-application) (s stream))
   (format s "STATE-PREP[(~{~5$~^, ~}) -> (~{~5$~^, ~})] ~{~/cl-quil:instruction-fmt/~^ ~}"

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -407,6 +407,8 @@
    #:anonymous-gate-application-p       ; FUNCTION
    #:swap-application-p                 ; FUNCTION
 
+   #:pseudo-gate-application            ; CLASS
+
    #:circuit-application                ; CLASS
    #:circuit-application-definition     ; ACCESSOR
 
@@ -1031,6 +1033,8 @@
 
    #:gate-application                   ; CLASS
    #:gate-application-gate              ; GENERIC, METHOD
+
+   #:pseudo-gate-application            ; CLASS
 
    #:anonymous-gate-application-p       ; FUNCTION
 


### PR DESCRIPTION
Sometimes one has a need for a formal GATE-APPLICATION instruction that will never manifest as a gate object nor reify as a matrix.

This commit introduces the PSUEDO-GATE-APPLICATION class that makes these "purely formal" gate applications semantically distinct from "ordinary" GATE-APPLICATION instances.

A natural example is the STATE-PREP-APPLICATION class, which has been refactored to subclass PSEUDO-GATE-APPLICATION.