### PR TITLE
Hotfix: Forgot to mapcar class-name, nconc creates evil behavior

### DIFF
--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -12,7 +12,8 @@
 (defclass backend ()
   ()
   (:documentation "Every backend must be represented by a subclass of this abstract base class.")
-  (:metaclass abstract-class))
+  ;(:metaclass abstract-class)
+  )
 
 (defgeneric backend-name (backend-class)
   (:documentation "The user-accessible name for BACKEND-CLASS.")
@@ -59,11 +60,11 @@
                (let ((direct
                        (c2mop:class-direct-subclasses class)))
                  (when direct
-                   (setf backends (nconc backends direct))
+                   (setf backends (append backends direct))
                    (dolist (cl direct)
                      (add-backends cl))))))
       (add-backends (find-class 'backend))
-      (delete-duplicates backends :test #'eq))))
+      (mapcar #'class-name (remove-duplicates backends :test #'eq)))))
 
 (defun find-backend (backend-name)
   "Returns the backend class associated with the string BACKEND-NAME."

--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -12,7 +12,7 @@
 (defclass backend ()
   ()
   (:documentation "Every backend must be represented by a subclass of this abstract base class.")
-  ;(:metaclass abstract-class)
+  (:metaclass abstract-class)
   )
 
 (defgeneric backend-name (backend-class)


### PR DESCRIPTION
I'm still looking into it, but as it was written before, running the LIST-AVAILABLE-BACKENDS function twice caused a FOREVER HANG.

This change fixes quilc, but does not address the issue, which may be a bug in sbcl.

@stylewarning sorry this is so soon on the heels of the last one :'(