### PR TITLE
Hotfix: list-available-backends; nconc causes evil behavior

### DIFF
--- a/src/backends/common.lisp
+++ b/src/backends/common.lisp
@@ -59,11 +59,11 @@
                (let ((direct
                        (c2mop:class-direct-subclasses class)))
                  (when direct
-                   (setf backends (nconc backends direct))
+                   (setf backends (append backends direct))
                    (dolist (cl direct)
                      (add-backends cl))))))
       (add-backends (find-class 'backend))
-      (delete-duplicates backends :test #'eq))))
+      (mapcar #'class-name (remove-duplicates backends :test #'eq)))))
 
 (defun find-backend (backend-name)
   "Returns the backend class associated with the string BACKEND-NAME."


### PR DESCRIPTION
Two fixes. One: list-available-backends should return not classes but class names.

Two: the way it was written before, calling list-available-backends twice resulted in a hang leading to a heap overflow.

This change fixes quilc but does not address the issue, which may indicate a bug in sbcl.

