### PR TITLE
Call-Chip-Builder Function Accepts 'Linear' and 'Fully-Connected' Chips

### DIFF
--- a/src/chip-library/chip-table.lisp
+++ b/src/chip-library/chip-table.lisp
@@ -41,3 +41,5 @@ returns nil if not found."
 (install-chip-builder "16QMUX" 'q::build-16QMUX-chip)
 (install-chip-builder "bristlecone" 'q::build-bristlecone-chip)
 (install-chip-builder "ibmqx5" 'q::build-ibm-qx5)
+(install-chip-builder "linear" (lambda (nQ) (q::build-nq-linear-chip nQ)))
+(install-chip-builder "fully-connected" (lambda (nQ) (q::build-nq-fully-connected-chip nQ)))


### PR DESCRIPTION
Added `linear` and `fully-connected` to the available chips that could be called via the `call-chip-builder` function within `chip-library.lisp`.  They accept one argument, `nQ`, which is the number of qubits for which to build the chip.  They return a chip object same as all other chip-building functions do. 