### PR TITLE
Add quilc_last_error function

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,6 @@
+libquilc.so-*
+libquilc.dylib-*
+libquilc.py
+libquilc.c
+libquilc.h
+libquilc.core

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,12 +1,21 @@
 .PHONY: all clean
 
-all: libquilc.dylib
+OS:=$(shell uname -s)
+ifeq ($(OS), Darwin)
+	LIBQUILC_TARGET = libquilc.dylib
+	CCFLAGS = -dynamiclib
+else
+	LIBQUILC_TARGET = libquilc.so
+	CCFLAGS = -shared
+endif
+
+all: $(LIBQUILC_TARGET)
 
 libquilc.core libquilc.c libquilc.h libquilc.py: src/libquilc.lisp
 	sbcl --dynamic-space-size 4096 --load "src/build-image.lisp"
 
-libquilc.dylib: libquilc.core libquilc.c
-	gcc -dynamiclib -o $@ libquilc.c -lsbcl
+$(LIBQUILC_TARGET): libquilc.core libquilc.c
+	gcc $(CCFLAGS) -o $@ libquilc.c -lsbcl
 
 example: example.c libquilc.dylib
 	gcc src/example.c -o example -lsbcl -lquilc -L.

--- a/lib/src/libquilc.lisp
+++ b/lib/src/libquilc.lisp
@@ -26,5 +26,9 @@
    (("compile_protoquil" compile-protoquil) quil-program ((program quil-program) (chip-spec chip-specification)))
    (("build_nq_linear_chip" cl-quil::build-nq-linear-chip) chip-specification ((n :int)))
    (("chip_spec_from_isa_descriptor" quilc::lookup-isa-descriptor-for-name) chip-specification ((descriptor :string)))
-   (("print_chip_spec" cl-quil::debug-print-chip-spec) :void ((chip-spec chip-specification)))))
+   (("print_chip_spec" cl-quil::debug-print-chip-spec) :void ((chip-spec chip-specification)))
+   (("parse_chip_spec_isa_json" cl-quil::qpu-hash-table-to-chip-specification) chip-specification ((isa-json :string)))
+   (("program_string" program-to-string) :string ((program quil-program)))))
 
+(defun program-to-string (program)
+  (cl-quil.frontend:print-parsed-program program s))

--- a/lib/src/libquilc.lisp
+++ b/lib/src/libquilc.lisp
@@ -29,15 +29,19 @@
    (("build_nq_linear_chip" cl-quil::build-nq-linear-chip) chip-specification ((n :int)))
    (("chip_spec_from_isa_descriptor" quilc::lookup-isa-descriptor-for-name) chip-specification ((descriptor :string)))
    (("print_chip_spec" cl-quil::debug-print-chip-spec) :void ((chip-spec chip-specification)))
-   (("parse_chip_spec_isa_json" cl-quil::qpu-hash-table-to-chip-specification) chip-specification ((isa-json :string)))
+   (("parse_chip_spec_isa_json" parse-chip-spec-isa-json) chip-specification ((isa-json :string)))
    (("program_string" program-to-string) :string ((program quil-program)))
    (("error" quilc-last-error) :string ())))
 
 (defun program-to-string (program)
-  (cl-quil.frontend:print-parsed-program program s))
+  (with-output-to-string (s)
+    (cl-quil.frontend:print-parsed-program program s)))
 
 (defun quilc-last-error ()
   "Returns the most recent error raised by quilc. The error is then cleared."
   (let ((last-error *last-error*))
     (setf *last-error* "")
     last-error))
+
+(defun parse-chip-spec-isa-json (isa-json)
+  (cl-quil::qpu-hash-table-to-chip-specification (yason:parse isa-json)))

--- a/lib/tests/c/.gitignore
+++ b/lib/tests/c/.gitignore
@@ -1,0 +1,3 @@
+compile-quil
+compile-protoquil
+print-chip-spec

--- a/lib/tests/c/Makefile
+++ b/lib/tests/c/Makefile
@@ -12,7 +12,7 @@ endif
 all: $(TEST_SRCS:.c=)
 
 %: %.c
-	gcc $(CCFLAGS) $< -o $@
+	gcc $< -o $@ $(CCFLAGS)
 
 clean:
 	rm -f $(TEST_SRCS:.c=)

--- a/lib/tests/c/compile-protoquil.c
+++ b/lib/tests/c/compile-protoquil.c
@@ -27,7 +27,16 @@ int main(int argc, char **argv) {
   if (quilc_compile_protoquil(program, chip_spec, &processed_program) != ERROR_SUCCESS)
     die("unable to compile program");
 
-  quilc_print_program(processed_program);
+  int compiled_program_length = 0;
+  if (quilc_program_length(processed_program, &compiled_program_length) != ERROR_SUCCESS)
+    die("unable to get program length");
+
+  char* program_string = malloc(compiled_program_length*sizeof(char));
+  if (quilc_program_string(processed_program, &program_string) != ERROR_SUCCESS)
+    die("unable to get program string");
+
+  printf("%s\n", program_string);
+
   lisp_release_handle(program);
   lisp_release_handle(processed_program);
   lisp_release_handle(chip_spec);


### PR DESCRIPTION
Modelled after e.g. [dlerror](https://linux.die.net/man/3/dlerror), the most recent error raised by `quilc` is captured in `*quilc-last-error*`. Calling `quilc-last-error` (or `quilc_last_error` depending on language) will
1. return the value in `*quilc-last-error*`; and
2. set `*quilc-last-error*` to `""`.

Obviously no guarantees around thread safety.