### PR TITLE
updating deps for abstract and singleton classes

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -13,8 +13,8 @@
                (:version #:magicl/core "0.10.0")
                #:qvm
                #:cl-grnm                ; nelder-mead implementation
-               #:singleton-classes
-               #:abstract-classes
+               #:org.tfeb.hax.abstract-classes
+               #:org.tfeb.hax.singleton-classes
                #:yason                  ; JSON generation
                #:uiop
                #:split-sequence
@@ -101,8 +101,8 @@
                #:yacc                   ; Arithmetic parsing
                #:alexandria             ; Utilities
                #:parse-float            ; Float parsing
-               #:singleton-classes
-               #:abstract-classes
+               #:org.tfeb.hax.abstract-classes
+               #:org.tfeb.hax.singleton-classes
                #:split-sequence
                #:cl-algebraic-data-type
                #:cl-permutation

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -27,8 +27,8 @@
 (defpackage #:cl-quil.frontend
   (:use #:cl
         #:parse-float
-        #:abstract-classes
-        #:singleton-classes)
+        #:org.tfeb.hax.abstract-classes
+        #:org.tfeb.hax.singleton-classes)
   (:local-nicknames (#:a #:alexandria))
   ;; frontend-options.lisp
   (:export
@@ -741,7 +741,7 @@
   (:use #:cl
         #:cl-quil.resource
         #:cl-quil.frontend
-        #:abstract-classes)
+        #:org.tfeb.hax.abstract-classes)
   (:local-nicknames (#:a #:alexandria))
   
   ;; options.lisp

--- a/src/quilt/package.lisp
+++ b/src/quilt/package.lisp
@@ -11,8 +11,8 @@
   (:nicknames #:quilt)
   (:use #:cl
         #:cl-quil.frontend
-        #:abstract-classes
-        #:singleton-classes)
+        #:org.tfeb.hax.abstract-classes
+        #:org.tfeb.hax.singleton-classes)
   ;; We define a number of methods on generic functions from
   ;; CL-QUIL. We import these here, as well as other internal symbols
   ;; that we want to get our hands on.


### PR DESCRIPTION
the cl-abstract-classes system available through quicklisp references a dead source URL. The author of this system, Tim Bradshaw, has factored this one system into two, renamed them, and changed he source URLS. This commit updates package and system names accordingly.

This commit has a sister commit in QVM, which also depends on abstract classes.

See also https://github.com/quil-lang/qvm/pull/318