### PR TITLE
Forbid the declaration of zero-length classical vectors

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1301,7 +1301,10 @@ If REQUIRE-INDENT is T, a parse error is signalled if entries are not properly i
       (:aref
        (let ((top-token (pop line)))
          (setf type (parse-quil-type (car (token-payload top-token))))
-         (setf length (cdr (token-payload top-token))))))
+         (let ((vector-length (cdr (token-payload top-token))))
+           (when (= 0 vector-length)
+             (quil-parse-error "Expected non-zero-length vector in DECLARE."))
+           (setf length vector-length)))))
 
     ;; Check for SHARING
     (unless (endp line)

--- a/tests/bad-test-files/bad-empty-vector.quil
+++ b/tests/bad-test-files/bad-empty-vector.quil
@@ -1,0 +1,7 @@
+# zero-length vector
+
+DECLARE r BIT[0]
+
+I 0
+
+MEASURE 0 r[0]


### PR DESCRIPTION
If zero-length vectors are allowed, qvm crashes in `allocate-memory-for-model` with the error:

    The value of QVM::SIZE is 0, which is not The SIZE wasn't a multiple of 8..
       [Condition of type SIMPLE-TYPE-ERROR]