### PR TITLE
Add support for clos-encounters

### DIFF
--- a/cl-quil.asd
+++ b/cl-quil.asd
@@ -13,8 +13,7 @@
                (:version #:magicl/core "0.10.0")
                #:qvm
                #:cl-grnm                ; nelder-mead implementation
-               #:org.tfeb.hax.abstract-classes
-               #:org.tfeb.hax.singleton-classes
+               #:clos-encounters
                #:yason                  ; JSON generation
                #:uiop
                #:split-sequence
@@ -101,8 +100,7 @@
                #:yacc                   ; Arithmetic parsing
                #:alexandria             ; Utilities
                #:parse-float            ; Float parsing
-               #:org.tfeb.hax.abstract-classes
-               #:org.tfeb.hax.singleton-classes
+               #:clos-encounters
                #:split-sequence
                #:cl-algebraic-data-type
                #:cl-permutation

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -27,8 +27,7 @@
 (defpackage #:cl-quil.frontend
   (:use #:cl
         #:parse-float
-        #:org.tfeb.hax.abstract-classes
-        #:org.tfeb.hax.singleton-classes)
+        #:clos-encounters)
   (:local-nicknames (#:a #:alexandria))
   ;; frontend-options.lisp
   (:export
@@ -744,7 +743,7 @@
   (:use #:cl
         #:cl-quil.resource
         #:cl-quil.frontend
-        #:org.tfeb.hax.abstract-classes)
+        #:clos-encounters)
   (:local-nicknames (#:a #:alexandria))
   
   ;; options.lisp

--- a/src/quilt/package.lisp
+++ b/src/quilt/package.lisp
@@ -11,8 +11,7 @@
   (:nicknames #:quilt)
   (:use #:cl
         #:cl-quil.frontend
-        #:org.tfeb.hax.abstract-classes
-        #:org.tfeb.hax.singleton-classes)
+        #:clos-encounters)
   ;; We define a number of methods on generic functions from
   ;; CL-QUIL. We import these here, as well as other internal symbols
   ;; that we want to get our hands on.


### PR DESCRIPTION
Fixes #917 in conjunction with a [similar PR to QVM](https://github.com/quil-lang/qvm/pull/321)

This PR relies on a new dependency to quil-lang software called [clos-encounters](https://github.com/quil-lang/clos-encounters), which implements common OOP patterns presently in use in quilc and qvm. CLOS-ENCOUNTERS is meant to be a drop-in replacement for the tfeb abstract classes and singleton classes libraries that we have been using. 

The [tfeb libraries](https://github.com/tfeb/tfeb-lisp-hax) utilized lazy-loading of a dependency (`closer-mop`) in a manner that broke our build process. Because these OOP patterns are so easy to implement, we've simply done so here rather than making a PR tfeb's repo.